### PR TITLE
Update organization length check

### DIFF
--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -173,7 +173,7 @@ class Enumerator:
 
         Output.info(
             f"About to enumerate "
-            f"{len(organization.private_repos) + len(organization.public_repos)}"
+            f"{len(enum_list)}"
             " repos within "
             f"the {organization.name} organization!"
         )


### PR DESCRIPTION
Found a minor bug when running `gato-x enum --self-enumeration`:

The organization.private_repo list was ending up empty, so this line `f"{len(organization.private_repos) + len(organization.public_repos)}"` was returning zero. Not sure at what point that list should be populated, so for now I updated the print statement to use the length of the `enum_list`.