### PR TITLE
Fix SH runner false negative

### DIFF
--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -137,7 +137,7 @@ class Api():
                             # they will have the image name. Skip if we see this.
                             # If the log contains "job is about to start running on hosted runner", 
                             # the runner is a Github hosted runner so we can skip it. 
-                            break
+                            continue
                         elif "Self-hosted runners in the repository are disabled" in content:
                             break
                         index = 0


### PR DESCRIPTION
Gato-X had an issue where it was exiting runlog enumeration early if the log indicated it was on a github hosted or larger runner. In practice, this meant if a workflow had multiple jobs, and the second was on a self-hosted runner, then Gato-X would miss it.