### PR TITLE
Use multithreading for GraphQL workflow ingestion

### DIFF
--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -1,5 +1,7 @@
 import logging
-import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait, as_completed
+from concurrent.futures import ALL_COMPLETED
 
 from gatox.github.api import Api
 from gatox.github.gql_queries import GqlQueries
@@ -87,35 +89,17 @@ class Enumerator:
     def __query_graphql_workflows(self, queries):
         """Wrapper for querying workflows using the github graphql API.
 
-        This method will try the query up to 3 times, as there are often intermittend 
-        failures.
+        Since this is an IO heavy operation, we use a threadpool with 5 workers to execute up
+        to 5 queries in parallel.
         """
-        for i, wf_query in enumerate(queries):
-            Output.info(f"Querying {i} out of {len(queries)} batches!", end='\r')
-            try:
-                for i in range (0, 3):
-                    result = self.api.call_post('/graphql', wf_query)
-                    # Sometimes we don't get a 200, fall back in this case.
-                    if result.status_code == 200:
-                        json_res = result.json()['data']
-                        if 'nodes' in json_res:
-                            DataIngestor.construct_workflow_cache(result.json()['data']['nodes'])
-                        else:
-                            DataIngestor.construct_workflow_cache(result.json()['data'].values())
-                        break
-                    else:
-                        Output.warn(
-                            f"GraphQL query failed with {result.status_code} "
-                            f"on attempt {str(i+1)}, will try again!")
-                        time.sleep(10)
-                        Output.warn(f"Query size was: {len(wf_query)}")
-            except Exception as e:
-                Output.warn(
-                    "Exception while running GraphQL query, will revert to REST "
-                    "API workflow query for impacted repositories!"
-                )
-                print(e)
-
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            Output.info(f"Querying repositories in {len(queries)} batches!")
+            futures = []
+            for i, wf_query in enumerate(queries):
+                futures.append(executor.submit(DataIngestor.perform_query, self.api, wf_query))
+            for future in as_completed(futures):
+                DataIngestor.construct_workflow_cache(future.result())
+           
     def validate_only(self):
         """Validates the PAT access and exits.
         """
@@ -222,6 +206,7 @@ class Enumerator:
             self.user_perms['scopes'], organization
         )
 
+        Output.info("Querying repository list!")
         enum_list = self.org_e.construct_repo_enum_list(organization)
 
         Output.info(

--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 
@@ -89,15 +88,15 @@ class Enumerator:
     def __query_graphql_workflows(self, queries):
         """Wrapper for querying workflows using the github graphql API.
 
-        Since this is an IO heavy operation, we use a threadpool with 2 workers to execute up
-        to 2 queries in parallel.
+        Since this is an IO heavy operation, we use a threadpool with 3 workers.
         """
-        with ThreadPoolExecutor(max_workers=2) as executor:
+        with ThreadPoolExecutor(max_workers=3) as executor:
             Output.info(f"Querying repositories in {len(queries)} batches!")
             futures = []
             for i, wf_query in enumerate(queries):
                 futures.append(executor.submit(DataIngestor.perform_query, self.api, wf_query, i))
             for future in as_completed(futures):
+                Output.info(f"Processed {DataIngestor.check_status()}/{len(queries)} batches.", end='\r')
                 DataIngestor.construct_workflow_cache(future.result())
            
     def validate_only(self):

--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -1,7 +1,7 @@
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait, as_completed
-from concurrent.futures import ALL_COMPLETED
+from concurrent.futures import as_completed
 
 from gatox.github.api import Api
 from gatox.github.gql_queries import GqlQueries
@@ -89,14 +89,14 @@ class Enumerator:
     def __query_graphql_workflows(self, queries):
         """Wrapper for querying workflows using the github graphql API.
 
-        Since this is an IO heavy operation, we use a threadpool with 5 workers to execute up
-        to 5 queries in parallel.
+        Since this is an IO heavy operation, we use a threadpool with 2 workers to execute up
+        to 2 queries in parallel.
         """
-        with ThreadPoolExecutor(max_workers=5) as executor:
+        with ThreadPoolExecutor(max_workers=2) as executor:
             Output.info(f"Querying repositories in {len(queries)} batches!")
             futures = []
             for i, wf_query in enumerate(queries):
-                futures.append(executor.submit(DataIngestor.perform_query, self.api, wf_query))
+                futures.append(executor.submit(DataIngestor.perform_query, self.api, wf_query, i))
             for future in as_completed(futures):
                 DataIngestor.construct_workflow_cache(future.result())
            

--- a/gatox/enumerate/ingest/ingest.py
+++ b/gatox/enumerate/ingest/ingest.py
@@ -100,20 +100,13 @@ class DataIngestor:
                         return result.json()['data'].values()
                     break
                 elif result.status_code == 403:
-                    Output.warn(
-                        f"GraphQL query batch {str(batch)} hit secondary rate limit on attempt"
-                        f" {str(i+1)}, sleeping all query workers!"
-                    )
                     with cls.__rl_lock:
                         time.sleep(15 + random.randint(0,3))
                 else:
-                    Output.warn(
-                        f"GraphQL query batch {str(batch)} failed with {result.status_code} "
-                        f"on attempt {str(i+1)}!")
                     # Add some jitter
                     time.sleep(10 + random.randint(0,3))
            
-            Output.warn("GraphQL attempts failed, will revert to REST for impacted repos.")
+            Output.warn(f"GraphQL attempts failed for batch {str(batch)}, will revert to REST for impacted repos.")
         except Exception as e:
             Output.warn(
                 "Exception while running GraphQL query, will revert to REST "

--- a/gatox/enumerate/ingest/ingest.py
+++ b/gatox/enumerate/ingest/ingest.py
@@ -2,10 +2,7 @@ import time
 import random
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait, as_completed
-
-
-from queue import Queue
+from concurrent.futures import as_completed
 
 from gatox.caching.cache_manager import CacheManager
 from gatox.models.workflow import Workflow
@@ -24,6 +21,13 @@ class DataIngestor:
     @classmethod
     def update_count(cls, batch: int):
         """
+        Update the class-level counter if the provided batch number is greater than the current counter.
+    
+        Args:
+            batch (int): The batch number to compare with the current counter.
+    
+        Returns:
+            None
         """
         with cls.__lock:
             if batch > cls.__counter:
@@ -31,29 +35,44 @@ class DataIngestor:
 
     @classmethod
     def check_status(cls):
-        """
+        """ This method returns the value of the class variable __counter.
         """
         return cls.__counter
 
     @classmethod
     def perform_parallel_repo_ingest(cls, api, org, repo_count):
-        """Perform a parallel query of repositories up to the count
-        within a given organization.
+        """
+        Perform a parallel query of repositories up to the count within a given organization.
+    
+        Args:
+            api (object): The API client used to make the GET requests.
+            org (str): The organization name to query repositories from.
+            repo_count (int): The number of repositories to query.
+    
+        Returns:
+            list: A list of repositories retrieved from the organization.
         """
         repos = []
-
+    
         def make_query(increment):
-            """Makes query to retrieve repos for given page.
-            Attempts up to 5 times.
+            """
+            Makes a query to retrieve repositories for a given page.
+            Attempts up to 5 times if the request fails.
+    
+            Args:
+                increment (int): The page number to query.
+    
+            Returns:
+                list: A list of repositories for the given page, or None if the query fails.
             """
             get_params = {
                 "type": "public",
                 "per_page": 100,
                 "page": increment
             }
-
+    
             sleep_timer = 4
-            for i in range (0, 5):
+            for _ in range(0, 5):
                 repos = api.call_get(f'/orgs/{org}/repos', params=get_params)
                 if repos.status_code == 200:
                     return repos.json()
@@ -61,9 +80,9 @@ class DataIngestor:
                     time.sleep(sleep_timer)
                     sleep_timer = sleep_timer * 2
             Output.error("Unable to query. Will miss repositories.")
-
+    
         batches = (repo_count // 100) + 1
-
+    
         with ThreadPoolExecutor(max_workers=10) as executor:
             futures = []
             for batch in range(1, batches + 1):
@@ -72,23 +91,33 @@ class DataIngestor:
                 listing = future.result()
                 if listing:
                     repos.extend([repo for repo in listing if not repo['archived']])
-
+    
         return repos
 
     @classmethod
     def perform_query(cls, api, work_query, batch):
-        """Performs GraphQL query of repositories. Gato-X will use 3
-        attempts, increasing the sleep timer from 4, 8, and then finally 16 
-        seconds.
+        """
+        Performs a GraphQL query of repositories with up to 3 attempts, increasing the sleep timer from 4, 8, and then finally 16 seconds.
+    
+        Args:
+            api (object): The API client used to make the POST requests.
+            work_query (dict): The GraphQL query to be executed.
+            batch (int): The batch number for which the query is being performed.
+    
+        Returns:
+            list or dict: The nodes or values from the query result if successful, otherwise None.
+    
+        Raises:
+            Exception: If an error occurs during the query execution.
         """
         try:
-            for i in range (0, 4):
+            for _ in range(0, 4):
                 # We lock if another thread is sleeping due to a rate limit
                 # but if no other thread is sleeping, we want to move on
                 # to query.
                 while cls.__rl_lock.locked():
                     time.sleep(0.1)
-
+    
                 result = api.call_post('/graphql', work_query)
                 # Sometimes we don't get a 200, fall back in this case.
                 if result.status_code == 200:
@@ -98,14 +127,13 @@ class DataIngestor:
                         return result.json()['data']['nodes']
                     else:
                         return result.json()['data'].values()
-                    break
                 elif result.status_code == 403:
                     with cls.__rl_lock:
-                        time.sleep(15 + random.randint(0,3))
+                        time.sleep(15 + random.randint(0, 3))
                 else:
                     # Add some jitter
-                    time.sleep(10 + random.randint(0,3))
-           
+                    time.sleep(10 + random.randint(0, 3))
+    
             Output.warn(f"GraphQL attempts failed for batch {str(batch)}, will revert to REST for impacted repos.")
         except Exception as e:
             Output.warn(
@@ -116,35 +144,36 @@ class DataIngestor:
 
     @staticmethod
     def construct_workflow_cache(yml_results):
-        """Creates a cache of workflow yml files retrieved from graphQL. Since
-        graphql and REST do not have parity, we still need to use rest for most
-        enumeration calls. This method saves off all yml files, so during org
-        level enumeration if we perform yml enumeration the cached file is used
-        instead of making github REST requests. 
-
+        """
+        Creates a cache of workflow YAML files retrieved from GraphQL. Since GraphQL and REST do not have parity,
+        REST is still used for most enumeration calls. This method saves all YAML files, so during organization-level
+        enumeration, if YAML enumeration is performed, the cached file is used instead of making GitHub REST requests.
+    
         Args:
-            yml_results (list): List of results from individual GraphQL queries
-            (100 nodes at a time).
+            yml_results (list): List of results from individual GraphQL queries (100 nodes at a time).
+    
+        Returns:
+            None
         """
         if yml_results is None:
             return
-
+    
         cache = CacheManager()
         for result in yml_results:
             # If we get any malformed/missing data just skip it and 
             # Gato will fall back to the contents API for these few cases.
             if not result:
                 continue
-                
+    
             if 'nameWithOwner' not in result:
                 continue
-
+    
             owner = result['nameWithOwner']
             cache.set_empty(owner)
-            # Empty means no yamls, so just skip.
+            # Empty means no YAMLs, so just skip.
             if result['object']:
                 for yml_node in result['object']['entries']:
-                    yml_name = yml_node['name']      
+                    yml_name = yml_node['name']
                     if yml_node['type'] == 'blob' and \
                       (yml_name.lower().endswith('yml') \
                       or yml_name.lower().endswith('yaml')): 
@@ -152,8 +181,8 @@ class DataIngestor:
                             contents = yml_node['object']['text']
                             wf_wrapper = Workflow(owner, contents, yml_name)
                             
-                            cache.set_workflow(owner, yml_name, wf_wrapper) 
-
+                            cache.set_workflow(owner, yml_name, wf_wrapper)
+    
             repo_data = {
                 'full_name': result['nameWithOwner'],
                 'html_url': result['url'],
@@ -180,11 +209,11 @@ class DataIngestor:
                 'allow_forking': result['forkingAllowed'],
                 'environments': []
             }
-
+    
             if 'environments' in result and result['environments']:
                 # Capture environments not named github-pages
-                envs = [env['node']['name']  for env in result['environments']['edges'] if env['node']['name'] != 'github-pages']
+                envs = [env['node']['name'] for env in result['environments']['edges'] if env['node']['name'] != 'github-pages']
                 repo_data['environments'] = envs
-                    
+    
             repo_wrapper = Repository(repo_data)
             cache.set_repository(repo_wrapper)

--- a/gatox/enumerate/ingest/ingest.py
+++ b/gatox/enumerate/ingest/ingest.py
@@ -57,7 +57,6 @@ class DataIngestor:
         seconds.
         """
         try:
-            sleep_timer = 5
             for i in range (0, 4):
                 result = api.call_post('/graphql', work_query)
                 # Sometimes we don't get a 200, fall back in this case.
@@ -73,14 +72,13 @@ class DataIngestor:
                         f"GraphQL query batch {str(batch)} hit secondary rate limit on attempt"
                         f" {str(i+1)}!"
                     )
-                    sleep_timer = sleep_timer * 2
-                    time.sleep(sleep_timer + random.randint(0,3))
+                    time.sleep(15 + random.randint(0,3))
                 else:
                     Output.warn(
                         f"GraphQL query batch {str(batch)} failed with {result.status_code} "
                         f"on attempt {str(i+1)}!")
                     # Add some jitter
-                    time.sleep(sleep_timer + random.randint(0,3))
+                    time.sleep(10 + random.randint(0,3))
            
             Output.warn("GraphQL attempts failed, will revert to REST for impacted repos.")
         except Exception as e:

--- a/gatox/github/gql_queries.py
+++ b/gatox/github/gql_queries.py
@@ -183,8 +183,8 @@ class GqlQueries():
         
         queries = []
 
-        for i in range(0, len(repos), 100):
-            chunk = repos[i:i + 100]
+        for i in range(0, len(repos), 50):
+            chunk = repos[i:i + 50]
             repo_queries = []
 
             for j, repo in enumerate(chunk):

--- a/gatox/github/gql_queries.py
+++ b/gatox/github/gql_queries.py
@@ -183,8 +183,8 @@ class GqlQueries():
         
         queries = []
 
-        for i in range(0, len(repos), 50):
-            chunk = repos[i:i + 50]
+        for i in range(0, len(repos), 100):
+            chunk = repos[i:i + 100]
             repo_queries = []
 
             for j, repo in enumerate(chunk):

--- a/unit_test/test_enumerate.py
+++ b/unit_test/test_enumerate.py
@@ -345,7 +345,6 @@ def test_enum_repo(mock_api, capfd):
         "octocat/Hello-World"
     )
 
-
 @patch("gatox.enumerate.enumerate.Api")
 def test_enum_org(mock_api, capfd):
 
@@ -501,9 +500,8 @@ def test_enum_repo_runner(mock_api, capfd):
         escaped_output
 
 
-@patch('gatox.enumerate.enumerate.time')
 @patch("gatox.enumerate.enumerate.Api")
-def test_enum_repos(mock_api, mock_time, capfd):
+def test_enum_repos(mock_api, capfd):
 
     mock_api.return_value.check_user.return_value = {
         "user": 'testUser',

--- a/unit_test/test_enumerate.py
+++ b/unit_test/test_enumerate.py
@@ -319,9 +319,9 @@ def test_enum_validate(mock_api, capfd):
         out
     )
 
-
+@patch("gatox.enumerate.ingest.ingest.time")
 @patch("gatox.enumerate.enumerate.Api")
-def test_enum_repo(mock_api, capfd):
+def test_enum_repo(mock_api, mock_time, capfd):
 
     mock_api.return_value.check_user.return_value = {
         "user": 'testUser',
@@ -345,8 +345,9 @@ def test_enum_repo(mock_api, capfd):
         "octocat/Hello-World"
     )
 
+@patch("gatox.enumerate.ingest.ingest.time")
 @patch("gatox.enumerate.enumerate.Api")
-def test_enum_org(mock_api, capfd):
+def test_enum_org(mock_api, mock_time, capfd):
 
     mock_api.return_value.check_user.return_value = {
         "user": 'testUser',
@@ -500,8 +501,9 @@ def test_enum_repo_runner(mock_api, capfd):
         escaped_output
 
 
+@patch("gatox.enumerate.ingest.ingest.time")
 @patch("gatox.enumerate.enumerate.Api")
-def test_enum_repos(mock_api, capfd):
+def test_enum_repos(mock_api, mock_time, capfd):
 
     mock_api.return_value.check_user.return_value = {
         "user": 'testUser',

--- a/unit_test/test_ingest.py
+++ b/unit_test/test_ingest.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import MagicMock
+from gatox.enumerate.ingest.ingest import DataIngestor
+from gatox.caching.cache_manager import CacheManager
+
+class TestConstructWorkflowCache(unittest.TestCase):
+
+    def setUp(self):
+        self.workflow = MagicMock()
+        self.repository = MagicMock()
+        CacheManager._instance = None
+        self.cache_manager = CacheManager()
+        Workflow = MagicMock(return_value=self.workflow)
+        Repository = MagicMock(return_value=self.repository)
+        self.yml_results = [
+            {
+                'nameWithOwner': 'owner/repo1',
+                'object': {
+                    'entries': [
+                        {
+                            'name': 'workflow1.yml',
+                            'type': 'blob',
+                            'object': {'text': 'content1'}
+                        }
+                    ]
+                },
+                'url': 'http://example.com/repo1',
+                'isPrivate': False,
+                'defaultBranchRef': {'name': 'main'},
+                'isFork': False,
+                'stargazers': {'totalCount': 10},
+                'pushedAt': '2023-01-01T00:00:00Z',
+                'viewerPermission': 'ADMIN',
+                'isArchived': False,
+                'forkingAllowed': True,
+                'environments': {'edges': []}
+            }
+        ]
+
+    def test_construct_workflow_cache_none(self):
+        # Test with None input
+        assert DataIngestor.construct_workflow_cache(None) is None
+
+    def test_construct_workflow_cache_empty_list(self):
+        # Test with empty list input
+        DataIngestor.construct_workflow_cache([])
+
+        assert CacheManager()._instance.repo_wf_lookup == {}
+        assert CacheManager()._instance.workflow_cache == {}
+        
+    def test_construct_workflow_cache_valid_input(self):
+        # Test with valid input
+        DataIngestor.construct_workflow_cache(self.yml_results)
+
+        assert CacheManager().is_repo_cached('owner/repo1') is True
+
+    def test_construct_workflow_cache_malformed_data(self):
+        # Test with malformed data
+        malformed_data = [{'invalid_key': 'invalid_value'}]
+        DataIngestor.construct_workflow_cache(malformed_data)
+
+        assert not CacheManager().is_repo_cached('invalid_key')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is the first step in resolving #11. I've moved both the organization repo list query and GraphQL workflow query functionality into the Ingest class. The speed increase is quite impressive. At this point the biggest limiting factor is GitHub's secondary rate limits. Since this is an IO-bound operation it's good to start with multi-threading because the GIL is not going to be the limiting factor.


`gato-x e -t microsoft -sr`: Enumeration of 4829 repositories with run log analysis off.

- Start `Sun Sep 15 01:07:00 EDT 2024`
- End `Sun Sep 15 01:09:47 EDT 2024`

This used to take over 10 minutes.