### PR TITLE
Improve validation clarity for different token types.

### DIFF
--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -88,10 +88,14 @@ def validate_arguments(args, parser):
             f"{Fore.RED}[!] Fine-grained PATs are currently not supported!"
         )
 
-    if not ("ghp_" in gh_token or "gho_" in gh_token or "ghu_" in
-            gh_token or re.match('^[a-fA-F0-9]{40}$', gh_token)):
-        parser.error(f"{Fore.RED}[!]{Style.RESET_ALL} Provided GitHub PAT is"
-                     " malformed!")
+    if not (re.match('gh[po]_[A-Za-z0-9]{36}$',gh_token) or
+            re.match('^[a-fA-F0-9]{40}$', gh_token)):
+        if re.match('gh[usr]_[A-Za-z0-9]{36}$', gh_token):
+            parser.error(f"{Fore.RED}[!]{Style.RESET_ALL} Gato-X only"
+                " supports GitHub OAuth and Personal Access Tokens.")
+        else:
+            parser.error(f"{Fore.RED}[!]{Style.RESET_ALL} Provided GitHub PAT is"
+                " malformed!")
 
     args_dict = vars(args)
     args_dict["gh_token"] = gh_token

--- a/unit_test/test_cli.py
+++ b/unit_test/test_cli.py
@@ -40,6 +40,25 @@ def test_cli_fine_grained_pat(capfd):
     out, err = capfd.readouterr()
     assert "not supported" in err
 
+def test_cli_s2s_token(capfd):
+    """Test case where a service-to-service token is provided.
+    """
+    os.environ["GH_TOKEN"] = "ghs_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    
+    with pytest.raises(SystemExit):
+        cli.cli(["enumerate", "-t", "test"])
+    out, err = capfd.readouterr()
+    assert "supports GitHub OAuth and Personal Access Tokens" in err
+
+def test_cli_u2s_token(capfd):
+    """Test case where a service-to-service token is provided.
+    """
+    os.environ["GH_TOKEN"] = "ghu_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    
+    with pytest.raises(SystemExit):
+        cli.cli(["enumerate", "-t", "test"])
+    out, err = capfd.readouterr()
+    assert "supports GitHub OAuth and Personal Access Tokens" in err
 
 @mock.patch("gatox.cli.cli.Enumerator")
 def test_cli_oauth_token(mock_enumerate, capfd):
@@ -68,9 +87,6 @@ def test_cli_old_token(mock_enumerate, capfd):
     """Test case where an old, but still potentially valid GitHub token is provided.
     """
     os.environ["GH_TOKEN"] = "43255147468edf32a206441ad296ce648f44ee32"
-
-
-    os.environ["GH_TOKEN"] = "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
     mock_instance = mock_enumerate.return_value
     mock_api = mock.MagicMock()


### PR DESCRIPTION
#23 called out that Gato-X says GitHub App tokens are malformed. This was misleading because the token type was correct, Gato-X just currently does not support app S2S or U2S tokens.