### PR TITLE
Improve Gato-X Release Process

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   bump-version:
-  if: ${{ github.actor == 'AdnaneKhan' }}
+    if: ${{ github.actor == 'AdnaneKhan' }}
     runs-on: ubuntu-latest
     env:
       NEW_VERSION: ${{ github.event.inputs.new_version }}

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -12,12 +12,15 @@ jobs:
   bump-version:
     if: ${{ github.actor == 'AdnaneKhan' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       NEW_VERSION: ${{ github.event.inputs.new_version }}
       BRANCH_NAME: bump_version_${{ github.event.inputs.new_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,0 +1,46 @@
+name: Bump Gato-X Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: 'New semantic version, e.g. 1.0.2'
+        required: true
+        type: string
+
+jobs:
+  bump-version:
+  if: ${{ github.actor == 'AdnaneKhan' }}
+    runs-on: ubuntu-latest
+    env:
+      NEW_VERSION: ${{ github.event.inputs.new_version }}
+      BRANCH_NAME: bump_version_${{ github.event.inputs.new_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update pyproject.toml with new version
+        run: |
+          echo "Updating pyproject.toml with version $NEW_VERSION"
+          sed -i "s/^version\s*=.*/version = \"$NEW_VERSION\"/" pyproject.toml
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Create and push branch
+        run: |
+          git checkout -b $BRANCH_NAME
+          git add pyproject.toml
+          git commit -m "Bump version to $NEW_VERSION"
+          git push origin $BRANCH_NAME
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: ${{ env.BRANCH_NAME }}
+          base: main
+          title: "Bump version to ${{ env.NEW_VERSION }}"
+          body: "This PR bumps the version to ${{ env.NEW_VERSION }}"
+          draft: false

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,0 +1,106 @@
+name: Gato-X Release Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check_version:
+    name: Check Version Bump
+    runs-on: ubuntu-latest
+    outputs:
+      version_bumped: ${{ steps.check.outputs.version_bumped }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Ensure access to the previous commit
+
+      - name: Check if version has been updated
+        id: check
+        run: |
+          PREV_VERSION=$(git show HEAD~1:pyproject.toml | grep "^version" | sed 's/version = "\(.*\)"/\1/')
+          CURR_VERSION=$(grep "^version" pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Previous version: $PREV_VERSION"
+          echo "Current version: $CURR_VERSION"
+          if [ "$PREV_VERSION" != "$CURR_VERSION" ]; then
+            echo "version_bumped=true" >> $GITHUB_OUTPUT
+            echo "version=$CURR_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "version_bumped=false" >> $GITHUB_OUTPUT
+            echo "version=$CURR_VERSION" >> $GITHUB_OUTPUT
+  build_artifact:
+    name: Build and upload artifact
+    runs-on: ubuntu-latest
+    needs: check_version
+    permissions:
+      id-token: write
+      attestations: write
+    if: needs.check_version.outputs.version_bumped == 'true'
+    steps:
+      - uses: actions/checkout@v4 
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build Binary wheel Source Tarball
+        run: python3 -m build
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'dist/gato_x-*'
+      - name: Store Distribution Packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+        path: dist/
+  release:
+    name:  Publish Gato-X Distribution 📦 to PyPI
+    needs: [check_version, build_artifact]
+    if: needs.check_version.outputs.version_bumped == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/gato-x
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+    - name: Publish Distribution
+      uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
+      with:
+        tag_name: v${{ needs.check_version.outputs.version }}
+        name: Gato-X Release v${{ needs.check_version.outputs.version }}
+        body: |
+          Release of version v${{ needs.check_version.outputs.version }}
+        files:
+          ./dist/*.tar.gz
+          ./dist/*.whl
+          ./dist/*.sigstore.json
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -62,7 +62,7 @@ jobs:
           name: python-package-distributions
         path: dist/
   release:
-    name:  Publish Gato-X Distribution 📦 to PyPI
+    name: Publish Gato-X Distribution 📦 to PyPI
     needs: [check_version, build_artifact]
     if: needs.check_version.outputs.version_bumped == 'true'
     runs-on: ubuntu-latest
@@ -83,24 +83,24 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-    - name: Publish Distribution
-      uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
-      with:
-        tag_name: v${{ needs.check_version.outputs.version }}
-        name: Gato-X Release v${{ needs.check_version.outputs.version }}
-        body: |
-          Release of version v${{ needs.check_version.outputs.version }}
-        files:
-          ./dist/*.tar.gz
-          ./dist/*.whl
-          ./dist/*.sigstore.json
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Distribution
+        uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
+        with:
+          tag_name: v${{ needs.check_version.outputs.version }}
+          name: Gato-X Release v${{ needs.check_version.outputs.version }}
+          body: |
+            Release of version v${{ needs.check_version.outputs.version }}
+          files:
+            ./dist/*.tar.gz
+            ./dist/*.whl
+            ./dist/*.sigstore.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR aims to improve the Gato-X release process by adding a version bump workflow and subsequent auto release workflow if a push to `main` contains a version bump. Additionally, the PR adds GitHub attestations for the distribution build.