### PR TITLE
Fix inconsistency with environment enumeration

### DIFF
--- a/gatox/github/gql_queries.py
+++ b/gatox/github/gql_queries.py
@@ -1,5 +1,6 @@
 from functools import reduce
 
+
 class GqlQueries:
     """Constructs graphql queries for use with the GitHub GraphQL api."""
 
@@ -222,28 +223,22 @@ class GqlQueries:
 
         for i in range(0, (len(repos) // 100) + 1):
 
-            top_len = len(repos) if len(repos) <  100 * (i + 1) else  100 * (i + 1)
+            top_len = len(repos) if len(repos) < 100 * (i + 1) else 100 * (i + 1)
             # Use reduce to accumulate node_ids and can_push in a single iteration
             node_ids, can_push = reduce(
                 lambda acc, repo: (
                     acc[0] + [repo.repo_data["node_id"]],
-                    acc[1] or repo.can_push()
+                    acc[1] or repo.can_push(),
                 ),
                 repos[100 * i : top_len],
-                ([], False)
+                ([], False),
             )
-            
+
             query = {
                 # We list envs if we have write access to one in the set (for secrets
                 # reasons, otherwise we don't list them)
-                "query": (
-                    GqlQueries.GET_YMLS_ENV
-                    if can_push
-                    else GqlQueries.GET_YMLS
-                ),
-                "variables": {
-                    "node_ids": node_ids
-                },
+                "query": (GqlQueries.GET_YMLS_ENV if can_push else GqlQueries.GET_YMLS),
+                "variables": {"node_ids": node_ids},
             }
 
             queries.append(query)


### PR DESCRIPTION
Query for environments if any of the repos in a batch is writeable, instead of just the first. This was leading to inconsistent results.