### PR TITLE
Process potential injection vars with checks for branch names

### DIFF
--- a/gatox/configuration/workflow_parsing.json
+++ b/gatox/configuration/workflow_parsing.json
@@ -65,6 +65,9 @@
             "github.event.pull_request.head.repo.default_branch",
             "github.head_ref"
         ],
+        "RISKY_CONTEXT_REGEXES": [
+            "(pr|PR).*(branch|head|ref)"
+        ],
         "SAFE_ISH_CONTEXTS": [
             "label",
             "flag",

--- a/gatox/enumerate/reports/actions.py
+++ b/gatox/enumerate/reports/actions.py
@@ -19,6 +19,7 @@ from gatox.configuration.configuration_manager import ConfigurationManager
 
 from gatox.enumerate.reports.report import Report
 from gatox.models.repository import Repository
+from gatox.workflow_parser.utility import check_risky_regexes
 
 
 class ActionsReport(Report):
@@ -173,6 +174,9 @@ class ActionsReport(Report):
                     in ConfigurationManager().WORKFLOW_PARSING["UNSAFE_CONTEXTS"]
                 ):
                     confidence = "HIGH"
+                elif confidence == "UNKNOWN" and var and check_risky_regexes(var):
+                    confidence = "MEDIUM"
+
             lines.append(f'Variables: {", ".join(val["variables"])}')
             if "if_checks" in val and val["if_checks"]:
                 lines.append(f' Step If-check: {val["if_checks"]}')

--- a/gatox/workflow_parser/utility.py
+++ b/gatox/workflow_parser/utility.py
@@ -1,3 +1,5 @@
+import re
+
 from gatox.configuration.configuration_manager import ConfigurationManager
 from gatox.workflow_parser.expression_parser import ExpressionParser
 from gatox.workflow_parser.expression_evaluator import ExpressionEvaluator
@@ -37,6 +39,15 @@ def check_sus(item):
             else:
                 return True
     return False
+
+
+@staticmethod
+def check_risky_regexes(item):
+    regexes = ConfigurationManager().WORKFLOW_PARSING["RISKY_CONTEXT_REGEXES"]
+
+    for regex in regexes:
+        if re.search(regex, item):
+            return True
 
 
 @staticmethod


### PR DESCRIPTION
This should help catch cases where branch names are retrieved using the GitHub API and then referenced via context expression in a run step.