### PR TITLE
Fix regression on the output yaml feature

### DIFF
--- a/gatox/caching/cache_manager.py
+++ b/gatox/caching/cache_manager.py
@@ -25,7 +25,6 @@ class CacheManager:
     """
     Singleton class that manages an in-memory cache for workflows and reusable actions.
 
-    TODO: Integrate with Redis.
     """
 
     _instance = None
@@ -42,7 +41,16 @@ class CacheManager:
             cls._instance.action_cache = {}
         return cls._instance
 
-    def get_workflow(self, repo_slug: str, workflow_name: str):
+    def get_repos(self) -> list:
+        """
+        Get all repository names from the in-memory dictionary.
+
+        Returns:
+            list: A list of repository names.
+        """
+        return list(self.repo_store.keys())
+
+    def get_workflow(self, repo_slug: str, workflow_name: str) -> Workflow:
         """
         Get a workflow from the in-memory dictionary.
 
@@ -83,7 +91,7 @@ class CacheManager:
         key = f"{repo_slug.lower()}:{action_path}:{ref}"
         return key in self.action_cache
 
-    def get_workflows(self, repo_slug: str):
+    def get_workflows(self, repo_slug: str) -> list:
         """
         Get all workflows for a repository from the in-memory dictionary.
 
@@ -127,7 +135,7 @@ class CacheManager:
         key = repository.name.lower()
         self.repo_store[key] = repository
 
-    def get_repository(self, repo_slug: str):
+    def get_repository(self, repo_slug: str) -> Repository:
         """
         Get a repository from the in-memory dictionary.
 

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -303,7 +303,6 @@ def enumerate(args, parser):
         args.gh_token,
         socks_proxy=args.socks_proxy,
         http_proxy=args.http_proxy,
-        output_yaml=args.output_yaml,
         skip_log=args.skip_runners,
         github_url=args.api_url,
         ignore_workflow_run=args.ignore_workflow_run,

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -1,11 +1,13 @@
 import argparse
 import os
+from pathlib import Path
 import re
 import logging
 
 from colorama import Fore, Style
 
 from gatox import util
+from gatox.caching.cache_manager import CacheManager
 from gatox.cli.colors import RED_DASH
 from gatox.cli.output import Output, SPLASH
 from gatox.caching.local_cache_manager import LocalCacheFactory
@@ -82,6 +84,20 @@ def cli(args):
     print(Output.blue(SPLASH))
 
     arguments.func(arguments, subparsers)
+
+
+def save_workflow_ymls(output_directory):
+    for repo in CacheManager().get_repos():
+        Path(os.path.join(output_directory, f"{repo}")).mkdir(
+            parents=True, exist_ok=True
+        )
+        for workflow in CacheManager().get_workflows(repo):
+            with open(
+                os.path.join(output_directory, f"{repo}/{workflow.workflow_name}"), "w"
+            ) as wf_out:
+                print(repo)
+                print(workflow.workflow_name)
+                wf_out.write(workflow.workflow_contents)
 
 
 def validate_arguments(args, parser):
@@ -341,6 +357,9 @@ def enumerate(args, parser):
             )
     elif args.repository:
         repos = gh_enumeration_runner.enumerate_repos([args.repository])
+
+    if args.output_yaml:
+        save_workflow_ymls(args.output_yaml)
 
     exec_wrapper.set_user_details(gh_enumeration_runner.user_perms)
     exec_wrapper.add_organizations(orgs)

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -95,8 +95,6 @@ def save_workflow_ymls(output_directory):
             with open(
                 os.path.join(output_directory, f"{repo}/{workflow.workflow_name}"), "w"
             ) as wf_out:
-                print(repo)
-                print(workflow.workflow_name)
                 wf_out.write(workflow.workflow_contents)
 
 

--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -37,7 +37,6 @@ class Enumerator:
         pat: str,
         socks_proxy: str = None,
         http_proxy: str = None,
-        output_yaml: str = None,
         skip_log: bool = False,
         github_url: str = None,
         output_json: str = None,
@@ -52,8 +51,6 @@ class Enumerator:
             Defaults to None.
             http_proxy (str, optional): Proxy gettings for HTTP proxy.
             Defaults to None.
-            output_yaml (str, optional): If set, directory to save all yml
-            files to . Defaults to None.
             skip_log (bool, optional): If set, then run logs will not be
             downloaded.
             output_json (str, optional): JSON file to output enumeration
@@ -69,14 +66,13 @@ class Enumerator:
         self.socks_proxy = socks_proxy
         self.http_proxy = http_proxy
         self.skip_log = skip_log
-        self.output_yaml = output_yaml
         self.user_perms = None
         self.github_url = github_url
         self.output_json = output_json
         self.deep_dive = deep_dive
         self.ignore_workflow_run = ignore_workflow_run
 
-        self.repo_e = RepositoryEnum(self.api, skip_log, output_yaml)
+        self.repo_e = RepositoryEnum(self.api, skip_log)
         self.org_e = OrganizationEnum(self.api)
 
     def __setup_user_info(self):

--- a/gatox/enumerate/repository.py
+++ b/gatox/enumerate/repository.py
@@ -1,5 +1,6 @@
 import logging
 
+from gatox.caching.cache_manager import CacheManager
 from gatox.enumerate.reports.runners import RunnersReport
 from gatox.cli.output import Output
 from gatox.enumerate.reports.actions import ActionsReport
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 class RepositoryEnum:
     """Repository specific enumeration functionality."""
 
-    def __init__(self, api: Api, skip_log: bool, output_yaml):
+    def __init__(self, api: Api, skip_log: bool):
         """Initialize enumeration class with instantiated API wrapper and CLI
         parameters.
 
@@ -23,8 +24,6 @@ class RepositoryEnum:
         """
         self.api = api
         self.skip_log = skip_log
-        self.output_yaml = output_yaml
-        self.temp_wf_cache = {}
 
     def perform_runlog_enumeration(self, repository: Repository, workflows: list):
         """Enumerate for the presence of a self-hosted runner based on

--- a/unit_test/test_enumerate.py
+++ b/unit_test/test_enumerate.py
@@ -72,7 +72,6 @@ def test_init(mock_api):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy="localhost:8080",
-        output_yaml=True,
         skip_log=False,
     )
 
@@ -96,7 +95,6 @@ def test_self_enumerate(mock_api, capsys):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy="localhost:8080",
-        output_yaml=True,
         skip_log=False,
     )
 
@@ -116,7 +114,6 @@ def test_enumerate_repo_admin(mock_api, capsys):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy="localhost:8080",
-        output_yaml=True,
         skip_log=False,
     )
 
@@ -151,7 +148,6 @@ def test_enumerate_repo_admin_no_wf(mock_api, capsys):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy="localhost:8080",
-        output_yaml=True,
         skip_log=False,
     )
 
@@ -194,7 +190,6 @@ def test_enum_validate(mock_api, capfd):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -221,7 +216,6 @@ def test_enum_repo(mock_api, mock_time, capfd):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -295,7 +289,6 @@ def test_enum_org(mock_api, mock_time, capfd):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -354,7 +347,6 @@ def test_enum_repo_runner(mock_api, capfd):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -387,7 +379,6 @@ def test_enum_repos(mock_api, mock_time, capfd):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -413,7 +404,6 @@ def test_enum_repos_empty(mock_api, capfd):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -430,7 +420,6 @@ def test_bad_token(mock_api):
         "ghp_BADTOKEN",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -450,7 +439,6 @@ def test_unscoped_token(mock_api, capfd):
         "ghp_BADTOKEN",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
     )
 
@@ -473,7 +461,6 @@ def test_enum_self_no_repos(mock_api, capfd):
         "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         socks_proxy=None,
         http_proxy=None,
-        output_yaml=False,
         skip_log=True,
         output_json="test.json",
     )

--- a/unit_test/test_repo_enumerate.py
+++ b/unit_test/test_repo_enumerate.py
@@ -36,7 +36,7 @@ def test_enumerate_repo():
     """Test constructor for enumerator."""
     mock_api = MagicMock()
 
-    gh_enumeration_runner = RepositoryEnum(mock_api, False, True)
+    gh_enumeration_runner = RepositoryEnum(mock_api, False)
 
     mock_api.check_user.return_value = {
         "user": "testUser",
@@ -70,7 +70,7 @@ def test_enumerate_repo_admin():
     """Test constructor for enumerator."""
     mock_api = MagicMock()
 
-    gh_enumeration_runner = RepositoryEnum(mock_api, False, True)
+    gh_enumeration_runner = RepositoryEnum(mock_api, False)
 
     mock_api.check_user.return_value = {
         "user": "testUser",
@@ -102,7 +102,7 @@ def test_enumerate_repo_secrets():
     """Test constructor for enumerator."""
     mock_api = MagicMock()
 
-    gh_enumeration_runner = RepositoryEnum(mock_api, False, True)
+    gh_enumeration_runner = RepositoryEnum(mock_api, False)
 
     mock_api.check_user.return_value = {
         "user": "testUser",

--- a/unit_test/test_save_workflow.py
+++ b/unit_test/test_save_workflow.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import patch, mock_open, MagicMock, call
+import os
+import pathlib
+from gatox.cli import cli
+from gatox.caching.cache_manager import CacheManager
+
+
+class TestSaveWorkflowYmls(unittest.TestCase):
+
+    @patch("gatox.cli.cli.CacheManager")
+    @patch("pathlib.Path.mkdir")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_workflow_ymls(self, mock_open_func, mock_mkdir, mock_cache_manager):
+        """Test that save_workflow_ymls correctly saves workflow files."""
+
+        # Mock CacheManager to return some repos and workflows
+        mock_cache_manager_instance = MagicMock()
+        mock_cache_manager.return_value = mock_cache_manager_instance
+
+        mock_cache_manager_instance.get_repos.return_value = ["repo1", "repo2"]
+
+        mock_workflow1 = MagicMock(
+            workflow_name="wf1.yml", workflow_contents="content1"
+        )
+        mock_workflow2 = MagicMock(
+            workflow_name="wf2.yml", workflow_contents="content2"
+        )
+        mock_cache_manager_instance.get_workflows.side_effect = [
+            [mock_workflow1],
+            [mock_workflow2],
+        ]
+
+        # Call the function
+        output_directory = "/tmp/test_output"
+        cli.save_workflow_ymls(output_directory)
+
+        # Assert that mkdir was called correctly
+        expected_calls = [
+            call(parents=True, exist_ok=True),
+            call(parents=True, exist_ok=True),
+        ]
+        mock_mkdir.assert_has_calls(expected_calls, any_order=True)
+        self.assertEqual(mock_mkdir.call_count, 2)
+
+        # Assert that open was called correctly and the contents were written
+        mock_open_func.assert_any_call(
+            os.path.join(output_directory, "repo1/wf1.yml"), "w"
+        )
+        mock_open_func.assert_any_call(
+            os.path.join(output_directory, "repo2/wf2.yml"), "w"
+        )
+
+        handler = mock_open_func()
+
+        handler.write.assert_any_call("content1")
+        handler.write.assert_any_call("content2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The overhaul for 1.0 removed the output yaml feature. This PR adds it back in a more modular manner instead of baked into the workflow parsing component.