### PR TITLE
fix: Handle multiple orgs during self enumeration.

### DIFF
--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -520,16 +520,27 @@ class Api:
             list(str): List of strings containing the organization names that
             the user is a member of.
         """
+        organizations = []
+        page = 1
+        per_page = 100
 
-        result = self.call_get("/user/orgs")
+        while True:
+            params = {"page": page, "per_page": per_page}
+            result = self.call_get("/user/orgs", params=params)
 
-        if result.status_code == 200:
+            if result.status_code == 200:
+                orgs = result.json()
+                if not orgs:
+                    break
+                
+                organizations.extend([org["login"] for org in orgs])
+                page += 1
+            elif result.status_code == 403:
+                break
+            else:
+                break
 
-            organizations = result.json()
-
-            return [org["login"] for org in organizations]
-        elif result.status_code == 403:
-            return []
+        return organizations
 
     def get_repository(self, repository: str):
         """Retrieve a repository using the GitHub API.

--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -532,7 +532,7 @@ class Api:
                 orgs = result.json()
                 if not orgs:
                     break
-                
+
                 organizations.extend([org["login"] for org in orgs])
                 page += 1
             elif result.status_code == 403:

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -422,6 +422,7 @@ def test_check_org(mock_get):
     assert result[3] == "org4"
     assert result[4] == "org5"
 
+
 @patch("gatox.github.api.requests.get")
 def test_retrieve_run_logs(mock_get):
     """Test retrieving run logs."""

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -391,12 +391,24 @@ def test_check_org(mock_get):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     mock_get().status_code = 200
 
-    mock_get.return_value.json.return_value = [
-        {"login": "org1"},
-        {"login": "org2"},
-        {"login": "org3"},
-        {"login": "org4"},
-        {"login": "org5"},
+    # Mock the API response to return orgs on the first call and an empty list on the second call
+    mock_get.side_effect = [
+        MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value=[
+                    {"login": "org1"},
+                    {"login": "org2"},
+                    {"login": "org3"},
+                    {"login": "org4"},
+                    {"login": "org5"},
+                ]
+            ),
+        ),
+        MagicMock(
+            status_code=200,
+            json=MagicMock(return_value=[]),
+        ),
     ]
 
     abstraction_layer = Api(test_pat, "2022-11-28")
@@ -405,7 +417,10 @@ def test_check_org(mock_get):
 
     assert len(result) == 5
     assert result[0] == "org1"
-
+    assert result[1] == "org2"
+    assert result[2] == "org3"
+    assert result[3] == "org4"
+    assert result[4] == "org5"
 
 @patch("gatox.github.api.requests.get")
 def test_retrieve_run_logs(mock_get):


### PR DESCRIPTION
Gato-X only retrieved 30 orgs the user belonged to. If the user belonged to more orgs, then Gato-X would only check 30 on the first page.

This PR updates API wrapper code to use pagination and retrieve all orgs the user is a member of.