### PR TITLE
Use HTTPX Instead of Requests Throughout

### DIFF
--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -156,7 +156,7 @@ class Enumerator:
                 CacheManager().set_repository(repo)
 
                 if repo:
-                    workflows = self.api.retrieve_workflow_ymls(repo)
+                    workflows = self.api.retrieve_workflow_ymls(repo.name)
 
                     for workflow in workflows:
                         CacheManager().set_workflow(

--- a/gatox/enumerate/ingest/ingest.py
+++ b/gatox/enumerate/ingest/ingest.py
@@ -19,7 +19,7 @@ import random
 import threading
 import logging
 
-from requests.exceptions import RequestException
+from httpx import RequestError
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 
@@ -137,7 +137,7 @@ class DataIngestor:
                     time.sleep(0.1)
                 try:
                     result = api.call_post("/graphql", work_query)
-                except RequestException:
+                except RequestError:
                     logging.error("Request exception occurred, trying again.")
                     time.sleep(15 + random.randint(0, 3))
                     continue

--- a/gatox/enumerate/ingest/ingest.py
+++ b/gatox/enumerate/ingest/ingest.py
@@ -137,8 +137,8 @@ class DataIngestor:
                     time.sleep(0.1)
                 try:
                     result = api.call_post("/graphql", work_query)
-                except RequestError:
-                    logging.error("Request exception occurred, trying again.")
+                except RequestError as e:
+                    logger.error(f"Request error occurred: {e}, trying again.")
                     time.sleep(15 + random.randint(0, 3))
                     continue
 

--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -80,7 +80,7 @@ class Api:
             self.verify_ssl = False
 
         self.client = httpx.Client(
-            headers=self.headers, proxy=self.transport, verify=self.verify_ssl
+            headers=self.headers, proxy=self.transport, verify=self.verify_ssl, follow_redirects=True
         )
 
     def __check_rate_limit(self, headers):
@@ -238,9 +238,13 @@ class Api:
 
     def __get_raw_file(self, repo: str, file_path: str, ref: str):
         """Get a raw file with a web request."""
+
         resp = self.client.get(
             f"https://raw.githubusercontent.com/{repo}/{ref}/{file_path}",
-            headers=self.headers,
+            headers={
+                "Authorization": "None",
+                "Accept": "text/plain",
+            }
         )
 
         if resp.status_code == 404:
@@ -1700,7 +1704,7 @@ class Api:
             file_path = file_path.replace("//", "/")
             paths = [file_path]
         else:
-            if not file_path.endswith("/"):
+            if file_path and not file_path.endswith("/"):
                 file_path += "/"
             elif file_path.endswith("//"):
                 file_path = file_path.replace("//", "/")

--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -234,7 +234,7 @@ class Api:
 
     def __get_raw_file(self, repo: str, file_path: str, ref: str):
         """Get a raw file with a web request."""
-   
+
         client = httpx.Client(proxy=self.transport, verify=self.verify_ssl)
         resp = client.get(
             f"https://raw.githubusercontent.com/{repo}/{ref}/{file_path}",
@@ -288,11 +288,13 @@ class Api:
         if strip_auth:
             del get_header["Authorization"]
 
-        client = httpx.Client(verify=self.verify_ssl, headers=get_header, proxy= self.transport)
+        client = httpx.Client(
+            verify=self.verify_ssl, headers=get_header, proxy=self.transport
+        )
         for _ in range(0, 5):
             try:
                 logger.debug(f"Making GET API request to {request_url}!")
-                
+
                 api_response = client.get(
                     request_url,
                     params=params,
@@ -322,11 +324,7 @@ class Api:
         logger.debug(f"Making POST API request to {request_url}!")
 
         client = httpx.Client(headers=self.headers, verify=self.verify_ssl)
-        api_response = client.post(
-            request_url,
-            json=params,
-            timeout=30
-        )
+        api_response = client.post(request_url, json=params, timeout=30)
         logger.debug(
             f"The POST request to {request_url} returned a "
             f"{api_response.status_code}!"
@@ -350,11 +348,10 @@ class Api:
         request_url = self.github_url + url
         logger.debug(f"Making PATCH API request to {request_url}!")
 
-        client = httpx.Client(headers=self.headers, verify=self.verify_ssl, proxy=self.transport)
-        api_response = client.patch(
-            request_url,
-            json=params
+        client = httpx.Client(
+            headers=self.headers, verify=self.verify_ssl, proxy=self.transport
         )
+        api_response = client.patch(request_url, json=params)
         logger.debug(
             f"The PATCH request to {request_url} returned a "
             f"{api_response.status_code}!"
@@ -375,11 +372,10 @@ class Api:
         request_url = self.github_url + url
         logger.debug(f"Making PUT API request to {request_url}!")
 
-        client = httpx.Client(headers=self.headers, proxy=self.transport, verify=self.verify_ssl) 
-        api_response = client.put(
-            request_url,
-            json=params
+        client = httpx.Client(
+            headers=self.headers, proxy=self.transport, verify=self.verify_ssl
         )
+        api_response = client.put(request_url, json=params)
 
         self.__check_rate_limit(api_response.headers)
 
@@ -399,11 +395,10 @@ class Api:
         request_url = self.github_url + url
         logger.debug(f"Making DELETE API request to {request_url}!")
 
-        client = httpx.Client(headers=self.headers, verify=self.verify_ssl, proxy=self.transport)
-        api_response = client.delete(
-            request_url,
-            json=params
+        client = httpx.Client(
+            headers=self.headers, verify=self.verify_ssl, proxy=self.transport
         )
+        api_response = client.delete(request_url, json=params)
         logger.debug(
             f"The POST request to {request_url} returned a "
             f"{api_response.status_code}!"

--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -80,7 +80,10 @@ class Api:
             self.verify_ssl = False
 
         self.client = httpx.Client(
-            headers=self.headers, proxy=self.transport, verify=self.verify_ssl, follow_redirects=True
+            headers=self.headers,
+            proxy=self.transport,
+            verify=self.verify_ssl,
+            follow_redirects=True,
         )
 
     def __check_rate_limit(self, headers):
@@ -244,7 +247,7 @@ class Api:
             headers={
                 "Authorization": "None",
                 "Accept": "text/plain",
-            }
+            },
         )
 
         if resp.status_code == 404:

--- a/gatox/notifications/send_webhook.py
+++ b/gatox/notifications/send_webhook.py
@@ -1,4 +1,4 @@
-import requests
+import httpx
 import json
 
 from gatox.configuration.configuration_manager import ConfigurationManager
@@ -11,7 +11,7 @@ def send_slack_webhook(message):
 
     for webhook in hooks:
         # Send the request
-        response = requests.post(webhook, json=payload)
+        response = httpx.post(webhook, json=payload)
         # Check the response
         if response.status_code != 200:
             raise ValueError(

--- a/gatox/search/search.py
+++ b/gatox/search/search.py
@@ -29,13 +29,11 @@ class Searcher:
             github_url=github_url,
         )
 
-        if self.api.proxies:
-            self.proxies = self.api.proxies
+        if self.api.transport:
+            self.transport = self.api.transport
         else:
-            self.proxies = None
+            self.transport = None
 
-        self.socks_proxy = socks_proxy
-        self.http_proxy = http_proxy
         self.user_perms = None
 
     def __setup_user_info(self):
@@ -102,7 +100,7 @@ class Searcher:
                 f"Searching SourceGraph with the default Gato query: {Output.bright(params['q'])}"
             )
         response = httpx.get(
-            url, headers=headers, params=params, stream=True, proxies=self.proxies
+            url, headers=headers, params=params, stream=True, proxy=self.transport
         )
         results = set()
         if response.status_code == 200:

--- a/gatox/search/search.py
+++ b/gatox/search/search.py
@@ -1,5 +1,5 @@
 import logging
-import requests
+import httpx
 import json
 
 from gatox.cli.output import Output
@@ -101,7 +101,7 @@ class Searcher:
             Output.info(
                 f"Searching SourceGraph with the default Gato query: {Output.bright(params['q'])}"
             )
-        response = requests.get(
+        response = httpx.get(
             url, headers=headers, params=params, stream=True, proxies=self.proxies
         )
         results = set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "colorama",
-    "requests",
+    "httpx[socks]",
     "pyyaml",
     "cryptography",
     "networkx"

--- a/test/runner_helper.py
+++ b/test/runner_helper.py
@@ -1,4 +1,4 @@
-import requests
+import httpx
 import os
 import sys
 
@@ -16,7 +16,7 @@ if sys.argv[1] == "remove":
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    response = requests.post(
+    response = httpx.post(
         "https://api.github.com/orgs/gatoxtest/actions/runners/remove-token",
         headers=headers,
     )
@@ -32,7 +32,7 @@ elif sys.argv[1] == "register":
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    response = requests.post(
+    response = httpx.post(
         "https://api.github.com/orgs/gatoxtest/actions/runners/registration-token",
         headers=headers,
     )
@@ -51,7 +51,7 @@ elif sys.argv[1] == "dispatch":
 
     data = {"ref": run_ref}
 
-    response = requests.post(
+    response = httpx.post(
         "https://api.github.com/repos/AdnaneKhan/gato-x/actions/workflows/integration_sh.yaml/dispatches",
         headers=headers,
         json=data,
@@ -68,7 +68,7 @@ elif sys.argv[1] == "force_remove":
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    response = requests.get(
+    response = httpx.get(
         "https://api.github.com/orgs/gatoxtest/actions/runners",
         headers=headers,
     )
@@ -84,7 +84,7 @@ elif sys.argv[1] == "force_remove":
 
         if runner:
             remove_id = runner[0]["id"]
-            resp = requests.delete(
+            resp = httpx.delete(
                 f"https://api.github.com/orgs/gatoxtest/actions/runners/{remove_id}",
                 headers=headers,
             )

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -848,10 +848,11 @@ def test_workflow_ymls(mock_client):
 def test_get_secrets(mock_client):
     """Test getting repo secret names."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
+
+    api = Api(test_pat, "2022-11-28")
 
     mock_instance.get.return_value.status_code = 200
     mock_instance.get.return_value.json.return_value = {
@@ -868,7 +869,6 @@ def test_get_secrets(mock_client):
 def test_get_org_secrets(mock_client):
     """Tests getting org secrets"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
@@ -902,6 +902,7 @@ def test_get_org_secrets(mock_client):
         },
     ]
 
+    api = Api(test_pat, "2022-11-28")
     secrets = api.get_org_secrets("testOrg")
 
     assert len(secrets) == 2
@@ -931,7 +932,6 @@ def test_get_org_secrets_empty(mock_client):
 def test_get_repo_org_secrets(mock_client):
     """Tests getting org secrets accessible to a repo."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
@@ -941,6 +941,8 @@ def test_get_repo_org_secrets(mock_client):
         "total_count": 3,
         "secrets": [{}, {}],
     }
+
+    api = Api(test_pat, "2022-11-28")
 
     secrets = api.get_repo_org_secrets("testOrg/testRepo")
 
@@ -1033,7 +1035,7 @@ def test_commit_workflow_failure(mock_client):
 
     assert result is None
     assert mock_instance.get.call_count == 4
-    assert mock_instance.post.call_count == 4
+    assert mock_instance.post.call_count == 1
 
 
 @patch("gatox.github.api.httpx.Client")
@@ -1068,13 +1070,12 @@ def test_commit_workflow_failure2(mock_client):
 
     assert result is None
     assert mock_instance.get.call_count == 4
-    assert mock_instance.post.call_count == 2
+    assert mock_instance.post.call_count == 1
 
 
 @patch("gatox.github.api.httpx.Client")
 def test_graphql_org_query(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
@@ -1109,6 +1110,7 @@ def test_graphql_org_query(mock_client):
     mock_instance.post.return_value.status_code = 200
     mock_instance.post.return_value.json.return_value = mock_results
 
+    api = Api(test_pat, "2022-11-28")
     names = api.get_org_repo_names_graphql("testOrg", "PUBLIC")
 
     assert "TestWF2" in names
@@ -1147,7 +1149,6 @@ def test_graphql_mergedat_query(mock_client):
     }
 
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
@@ -1155,6 +1156,7 @@ def test_graphql_mergedat_query(mock_client):
     mock_instance.post.return_value.status_code = 200
     mock_instance.post.return_value.json.return_value = mock_results
 
+    api = Api(test_pat, "2022-11-28")
     date = api.get_commit_merge_date(
         "testOrg/testRepo", "9659fdc7ba35a9eba00c183bccc67083239383e8"
     )
@@ -1166,10 +1168,11 @@ def test_graphql_mergedat_query(mock_client):
 def test_get_user_type(mock_client):
 
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
+
+    api = Api(test_pat, "2022-11-28")
 
     mock_instance.get.return_value.status_code = 200
     mock_instance.get.return_value.json.return_value = {"type": "User"}
@@ -1182,7 +1185,6 @@ def test_get_user_type(mock_client):
 @patch("gatox.github.api.httpx.Client")
 def test_get_user_repos(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
@@ -1193,6 +1195,7 @@ def test_get_user_repos(mock_client):
         {"full_name": "testRepo2", "archived": False},
     ]
 
+    api = Api(test_pat, "2022-11-28")
     repos = api.get_user_repos("someUser")
 
     assert repos[0] == "testRepo"
@@ -1202,7 +1205,6 @@ def test_get_user_repos(mock_client):
 @patch("gatox.github.api.httpx.Client")
 def test_get_own_repos_single_page(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
@@ -1213,6 +1215,8 @@ def test_get_own_repos_single_page(mock_client):
         {"full_name": "owner/testRepo", "archived": False},
         {"full_name": "owner/testRepo2", "archived": False},
     ]
+
+    api = Api(test_pat, "2022-11-28")
     repos = api.get_own_repos()
     assert repos == ["owner/testRepo", "owner/testRepo2"]
     mock_instance.get.assert_called_once()
@@ -1221,10 +1225,11 @@ def test_get_own_repos_single_page(mock_client):
 @patch("gatox.github.api.httpx.Client")
 def test_get_own_repos_multiple_pages(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
+
+    api = Api(test_pat, "2022-11-28")
 
     def generate_repo_list():
         """
@@ -1255,12 +1260,12 @@ def test_get_own_repos_multiple_pages(mock_client):
 
 @patch("gatox.github.api.httpx.Client")
 def test_get_own_repos_empty_response(mock_client):
-
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    api = Api(test_pat, "2022-11-28")
 
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
+
+    api = Api(test_pat, "2022-11-28")
 
     # Mock the API response for an empty response
 

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -44,8 +44,7 @@ def test_socks(api_access):
 
     abstraction_layer = Api(test_pat, "2022-11-28", socks_proxy="localhost:9090")
 
-    assert abstraction_layer.proxies["http"] == "socks5://localhost:9090"
-    assert abstraction_layer.proxies["https"] == "socks5://localhost:9090"
+    assert abstraction_layer.transport == "socks5://localhost:9090"
 
 
 def test_http_proxy(api_access):
@@ -55,8 +54,7 @@ def test_http_proxy(api_access):
 
     abstraction_layer = Api(test_pat, "2022-11-28", http_proxy="localhost:1080")
 
-    assert abstraction_layer.proxies["http"] == "http://localhost:1080"
-    assert abstraction_layer.proxies["https"] == "http://localhost:1080"
+    assert abstraction_layer.transport == "http://localhost:1080"
 
 
 @patch("gatox.github.api.httpx.Client")

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -61,11 +61,14 @@ def test_http_proxy(api_access):
 def test_user_scopes(mock_client):
     """Check user."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.headers.get.return_value = "repo, admin:org"
-    mock_instance.get.return_value.json.return_value = {"login": "TestUserName", "name": "TestUser"}
+    mock_instance.get.return_value.json.return_value = {
+        "login": "TestUserName",
+        "name": "TestUser",
+    }
     mock_instance.get.return_value.status_code = 200
 
     abstraction_layer = Api(test_pat, "2022-11-28")
@@ -93,7 +96,7 @@ def test_socks_and_http(api_access):
 @patch("gatox.github.api.httpx.Client")
 def test_validate_sso(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -107,7 +110,7 @@ def test_validate_sso(mock_client):
 @patch("gatox.github.api.httpx.Client")
 def test_validate_sso_fail(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 403
@@ -122,7 +125,7 @@ def test_validate_sso_fail(mock_client):
 def test_invalid_pat(mock_client):
     """Test calling a request with an invalid PAT"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 401
@@ -135,7 +138,7 @@ def test_invalid_pat(mock_client):
 def test_delete_repo(mock_client):
     """Test forking a repository"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.delete.return_value.status_code = 204
@@ -150,7 +153,7 @@ def test_delete_repo(mock_client):
 def test_delete_fail(mock_client):
     """Test forking a repository"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.delete.return_value.status_code = 403
@@ -165,11 +168,13 @@ def test_delete_fail(mock_client):
 def test_fork_repository(mock_client):
     """Test fork repo happy path"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.post.return_value.status_code = 202
-    mock_instance.post.return_value.json.return_value = {"full_name": "myusername/TestRepo"}
+    mock_instance.post.return_value.json.return_value = {
+        "full_name": "myusername/TestRepo"
+    }
 
     abstraction_layer = Api(test_pat, "2022-11-28")
     result = abstraction_layer.fork_repository("testOrg/TestRepo")
@@ -181,11 +186,13 @@ def test_fork_repository(mock_client):
 def test_fork_repository_forbid(mock_client):
     """Test repo fork forbidden."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.post.return_value.status_code = 403
-    mock_instance.post.return_value.json.return_value = {"full_name": "myusername/TestRepo"}
+    mock_instance.post.return_value.json.return_value = {
+        "full_name": "myusername/TestRepo"
+    }
 
     abstraction_layer = Api(test_pat, "2022-11-28")
     result = abstraction_layer.fork_repository("testOrg/TestRepo")
@@ -196,11 +203,13 @@ def test_fork_repository_forbid(mock_client):
 def test_fork_repository_notfound(mock_client):
     """Test repo fork 404."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.post.return_value.status_code = 404
-    mock_instance.post.return_value.json.return_value = {"full_name": "myusername/TestRepo"}
+    mock_instance.post.return_value.json.return_value = {
+        "full_name": "myusername/TestRepo"
+    }
 
     abstraction_layer = Api(test_pat, "2022-11-28")
     result = abstraction_layer.fork_repository("testOrg/TestRepo")
@@ -211,11 +220,13 @@ def test_fork_repository_notfound(mock_client):
 def test_fork_repository_fail(mock_client):
     """Test repo fork failure"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.post.return_value.status_code = 422
-    mock_instance.post.return_value.json.return_value = {"full_name": "myusername/TestRepo"}
+    mock_instance.post.return_value.json.return_value = {
+        "full_name": "myusername/TestRepo"
+    }
 
     abstraction_layer = Api(test_pat, "2022-11-28")
     result = abstraction_layer.fork_repository("testOrg/TestRepo")
@@ -226,7 +237,7 @@ def test_fork_repository_fail(mock_client):
 def test_fork_pr(mock_client):
     """Test creating a fork PR"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.post.return_value.status_code = 201
@@ -246,7 +257,7 @@ def test_fork_pr(mock_client):
 def test_fork_pr_failed(mock_client):
     """Test creating a fork PR"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.post.return_value.status_code = 401
@@ -266,7 +277,7 @@ def test_fork_pr_failed(mock_client):
 def test_get_repo(mock_client):
     """Test getting repo info."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -282,7 +293,7 @@ def test_get_repo(mock_client):
 def test_get_org(mock_client):
     """Test retrievign org info."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -298,7 +309,7 @@ def test_get_org(mock_client):
 def test_get_org_notfound(mock_client):
     """Test 404 code when retrieving org info."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 404
@@ -313,7 +324,7 @@ def test_get_org_notfound(mock_client):
 def test_check_org_runners(mock_client):
     """Test method to retrieve runners from org."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -329,7 +340,7 @@ def test_check_org_runners(mock_client):
 def test_check_org_runners_fail(mock_client):
     """Test method to retrieve runners from org."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 403
@@ -344,7 +355,7 @@ def test_check_org_runners_fail(mock_client):
 def test_check_repo_runners(mock_client):
     """Test method to retrieve runners from org."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -382,7 +393,7 @@ def test_check_org_repos_invalid(mock_client):
 def test_check_org_repos(mock_client):
     """Test method to retrieve runners from org."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -405,7 +416,7 @@ def test_check_org_repos(mock_client):
 def test_check_org(mock_client):
     """Test method to retrieve runners from org."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -446,7 +457,7 @@ def test_retrieve_run_logs(mock_client):
     """Test retrieving run logs."""
     curr_path = pathlib.Path(__file__).parent.resolve()
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -488,7 +499,7 @@ def test_retrieve_run_logs(mock_client):
 def test_parse_wf_runs(mock_client):
     """Test retrieving wf run count."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 200
@@ -505,7 +516,7 @@ def test_parse_wf_runs(mock_client):
 def test_parse_wf_runs_fail(mock_client):
     """Test 403 code when retrieving wf run count"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
     mock_instance.get.return_value.status_code = 403
@@ -520,7 +531,7 @@ def test_parse_wf_runs_fail(mock_client):
 def test_get_recent_workflow(mock_client):
     """Test retrieving a recent workflow by sha."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -540,7 +551,7 @@ def test_get_recent_workflow(mock_client):
 def test_get_recent_workflow_missing(mock_client):
     """Test retrieving a missing recent workflow by sha."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -561,7 +572,7 @@ def test_get_recent_workflow_missing(mock_client):
 def test_get_recent_workflow_fail(mock_client):
     """Test failing the retrieval of a recent workflow by sha."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -577,7 +588,7 @@ def test_get_recent_workflow_fail(mock_client):
 def test_get_workflow_status_queued(mock_client):
     """Test retrieving the status of a workflow."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -592,7 +603,7 @@ def test_get_workflow_status_queued(mock_client):
 def test_get_workflow_status_failed(mock_client):
     """Test retrieving the status of a workflow."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -610,7 +621,7 @@ def test_get_workflow_status_failed(mock_client):
 def test_get_workflow_status_errorr(mock_client):
     """Test retrieving the status of a workflow."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -624,7 +635,7 @@ def test_get_workflow_status_errorr(mock_client):
 def test_delete_workflow_fail(mock_client):
     """Test retrieving the status of a workflow."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -639,7 +650,7 @@ def test_delete_workflow_fail(mock_client):
 def test_download_workflow_success(mock_client, mock_open):
     """Test retrieving the status of a workflow."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -654,7 +665,7 @@ def test_download_workflow_success(mock_client, mock_open):
 def test_download_workflow_fail(mock_client, mock_open):
     """Test retrieving the status of a workflow."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -668,7 +679,7 @@ def test_download_workflow_fail(mock_client, mock_open):
 def test_get_repo_branch(mock_client):
     """Test retrieving the existence of a branch."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -688,7 +699,7 @@ def test_get_repo_branch(mock_client):
 def test_create_branch(mock_client):
     """Test creating a new branch"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -719,7 +730,7 @@ def test_create_branch(mock_client):
 def test_create_branch_fail(mock_client):
     """Test creating a new branch"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -751,7 +762,7 @@ def test_delete_branch(mock_client):
     """Test deleting branch"""
 
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -768,7 +779,7 @@ def test_commit_file(mock_client):
     test_filedata = b"foobarbaz"
 
     test_sha = "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -815,7 +826,7 @@ def test_workflow_ymls(mock_client):
     base64_enc = base64.b64encode(b"FooBarBaz")
 
     test_file_content = {"content": base64_enc}
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -838,7 +849,7 @@ def test_get_secrets(mock_client):
     """Test getting repo secret names."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -858,7 +869,7 @@ def test_get_org_secrets(mock_client):
     """Tests getting org secrets"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -904,7 +915,7 @@ def test_get_org_secrets_empty(mock_client):
     """Tests getting org secrets"""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -921,12 +932,15 @@ def test_get_repo_org_secrets(mock_client):
     """Tests getting org secrets accessible to a repo."""
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
     mock_instance.get.return_value.status_code = 200
-    mock_instance.get.return_value.json.return_value = {"total_count": 3, "secrets": [{}, {}]}
+    mock_instance.get.return_value.json.return_value = {
+        "total_count": 3,
+        "secrets": [{}, {}],
+    }
 
     secrets = api.get_repo_org_secrets("testOrg/testRepo")
 
@@ -958,18 +972,18 @@ def test_commit_workflow(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
-    
+
     mock_get_responses = [
         {"default_branch": "main"},
         {"sha": "123"},
         {"tree": {"sha": "456"}},
-        {"sha": "789", "tree": []}
+        {"sha": "789", "tree": []},
     ]
     mock_post_responses = [
         {"sha": "abc"},
         {"sha": "def"},
         {"sha": "ghi"},
-        {"sha": "jkl"}
+        {"sha": "jkl"},
     ]
 
     mock_instance.get.return_value.status_code = 200
@@ -978,7 +992,9 @@ def test_commit_workflow(mock_client):
     mock_instance.post.return_value.json.side_effect = mock_post_responses
 
     api = Api(test_pat, "2022-11-28")
-    result = api.commit_workflow("test_repo", "test_branch", b"test_content", "test_file")
+    result = api.commit_workflow(
+        "test_repo", "test_branch", b"test_content", "test_file"
+    )
 
     assert result == "ghi"
     assert mock_instance.get.call_count == 4
@@ -991,18 +1007,18 @@ def test_commit_workflow_failure(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
-    
+
     mock_get_responses = [
         {"default_branch": "main"},
         {"sha": "123"},
         {"tree": {"sha": "456"}},
-        {"sha": "789", "tree": []}
+        {"sha": "789", "tree": []},
     ]
     mock_post_responses = [
         {"sha": "abc"},
         {"sha": "def"},
         {"sha": "ghi"},
-        {"sha": "jkl"}
+        {"sha": "jkl"},
     ]
 
     mock_instance.get.return_value.status_code = 200
@@ -1011,7 +1027,9 @@ def test_commit_workflow_failure(mock_client):
     mock_instance.post.return_value.json.side_effect = mock_post_responses
 
     api = Api(test_pat, "2022-11-28")
-    result = api.commit_workflow("test_repo", "test_branch", b"test_content", "test_file")
+    result = api.commit_workflow(
+        "test_repo", "test_branch", b"test_content", "test_file"
+    )
 
     assert result is None
     assert mock_instance.get.call_count == 4
@@ -1024,18 +1042,18 @@ def test_commit_workflow_failure2(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
-    
+
     mock_get_responses = [
         {"default_branch": "main"},
         {"sha": "123"},
         {"tree": {"sha": "456"}},
-        {"sha": "789", "tree": []}
+        {"sha": "789", "tree": []},
     ]
     mock_post_responses = [
         {"sha": "abc"},
         {"sha": "def"},
         {"sha": "ghi"},
-        {"sha": "jkl"}
+        {"sha": "jkl"},
     ]
 
     mock_instance.get.return_value.status_code = 200
@@ -1044,7 +1062,9 @@ def test_commit_workflow_failure2(mock_client):
     mock_instance.post.return_value.json.side_effect = mock_post_responses
 
     api = Api(test_pat, "2022-11-28")
-    result = api.commit_workflow("test_repo", "test_branch", b"test_content", "test_file")
+    result = api.commit_workflow(
+        "test_repo", "test_branch", b"test_content", "test_file"
+    )
 
     assert result is None
     assert mock_instance.get.call_count == 4
@@ -1055,7 +1075,7 @@ def test_commit_workflow_failure2(mock_client):
 def test_graphql_org_query(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -1128,7 +1148,7 @@ def test_graphql_mergedat_query(mock_client):
 
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -1147,7 +1167,7 @@ def test_get_user_type(mock_client):
 
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -1163,7 +1183,7 @@ def test_get_user_type(mock_client):
 def test_get_user_repos(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -1183,7 +1203,7 @@ def test_get_user_repos(mock_client):
 def test_get_own_repos_single_page(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -1202,7 +1222,7 @@ def test_get_own_repos_single_page(mock_client):
 def test_get_own_repos_multiple_pages(mock_client):
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 
@@ -1238,7 +1258,7 @@ def test_get_own_repos_empty_response(mock_client):
 
     test_pat = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     api = Api(test_pat, "2022-11-28")
-    
+
     mock_instance = MagicMock()
     mock_client.return_value = mock_instance
 

--- a/unit_test/test_cli.py
+++ b/unit_test/test_cli.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import pathlib
-import requests  # If using the requests library
+import httpx
 
 from unittest import mock
 from unittest.mock import patch
@@ -20,7 +20,8 @@ def block_network_calls(monkeypatch):
     def mock_request(*args, **kwargs):
         raise RuntimeError("Blocked a real network call during tests.")
 
-    monkeypatch.setattr(requests.sessions.Session, "request", mock_request)
+    monkeypatch.setattr(httpx.Client, "send", mock_request)
+    monkeypatch.setattr(httpx.AsyncClient, "send", mock_request)
 
 
 @pytest.fixture(autouse=True)

--- a/unit_test/test_enumerate.py
+++ b/unit_test/test_enumerate.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import pytest
 import json
-import requests
+import httpx
 
 from unittest.mock import patch
 
@@ -41,7 +41,8 @@ def block_network_calls(monkeypatch):
     def mock_request(*args, **kwargs):
         raise RuntimeError("Blocked a real network call during tests.")
 
-    monkeypatch.setattr(requests.sessions.Session, "request", mock_request)
+    monkeypatch.setattr(httpx.Client, "send", mock_request)
+    monkeypatch.setattr(httpx.AsyncClient, "send", mock_request)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
Taking a different approach to eventually get the project to async. #87 starts by wrapping functionality with async and HTTPX, but it's a very heavy change that risks breaking the attack functionality (which is fairly involved to test, especially the automatic self-hosted runner takeover features)

Will try to first switch to httpx, test that everything still works, then work to move the entire codebase to async calls.