### PR TITLE
Fix syntax error with Output singleton

### DIFF
--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -79,7 +79,7 @@ async def cli(args):
 
     arguments = parser.parse_args(args)
 
-    Output(not arguments.no_color)
+    Output(color=not arguments.no_color)
     validate_arguments(arguments, parser)
     print(Output.blue(SPLASH))
 

--- a/gatox/cli/output.py
+++ b/gatox/cli/output.py
@@ -42,7 +42,7 @@ Y88b  d88P  d8888888888     888     Y88b. .d88P         d88P Y88b
 
 class Output(metaclass=Singleton):
 
-    def __init__(self, color: bool, suppress: bool = False):
+    def __init__(self, color: bool = True, suppress: bool = False):
         self.color = color
         self.suppress = suppress
 


### PR DESCRIPTION
MCP changes introduced a regression that was causing an error.