### PR TITLE
Add enumeration for app private keys

### DIFF
--- a/gatox/cli/app/__init__.py
+++ b/gatox/cli/app/__init__.py
@@ -1,1 +1,0 @@
-# GitHub App CLI module

--- a/gatox/cli/app/__init__.py
+++ b/gatox/cli/app/__init__.py
@@ -1,0 +1,1 @@
+# GitHub App CLI module

--- a/gatox/cli/app/config.py
+++ b/gatox/cli/app/config.py
@@ -9,39 +9,6 @@ def configure_parser_app(parser):
         parser: sub parser to add arguments to.
     """
 
-    # Add general arguments
-    parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        default="CRITICAL",
-        required=False,
-    )
-
-    parser.add_argument(
-        "--socks-proxy",
-        "-sp",
-        help=(
-            "SOCKS proxy to use for requests, in"
-            f" {Fore.GREEN}HOST{Style.RESET_ALL}:{Fore.GREEN}PORT"
-            f" {Style.RESET_ALL}format"
-        ),
-        required=False,
-    )
-
-    parser.add_argument(
-        "--http-proxy",
-        help=(
-            "HTTPS proxy to use for requests, in"
-            f" {Fore.GREEN}HOST{Style.RESET_ALL}:{Fore.GREEN}PORT"
-            f" {Style.RESET_ALL}format."
-        ),
-        required=False,
-    )
-
-    parser.add_argument(
-        "--no-color", "-nc", help="Removes all color from output.", action="store_true"
-    )
-
     parser.add_argument(
         "--app",
         "-a",
@@ -64,32 +31,16 @@ def configure_parser_app(parser):
 
     operation_group.add_argument(
         "--installations",
-        "-i",
         help="List all app installations with metadata including repositories and permissions.",
         action="store_true",
     )
 
     operation_group.add_argument(
-        "--full",
-        "-f",
-        help="Perform full enumeration on all maximally visible repositories across all installations.",
-        action="store_true",
-    )
-
-    operation_group.add_argument(
         "--installation",
-        "-I",
+        "-i",
         help="Enumerate a specific installation by ID.",
         metavar=f"{Fore.RED}INSTALLATION_ID{Style.RESET_ALL}",
         type=int,
-    )
-
-    parser.add_argument(
-        "--output-json",
-        "-oJ",
-        help="Save enumeration output to JSON file.",
-        metavar="JSON_FILE",
-        type=StringType(256),
     )
 
     parser.add_argument(
@@ -111,4 +62,12 @@ def configure_parser_app(parser):
             "Git is required on the PATH for this feature."
         ),
         action="store_true",
+    )
+
+    parser.add_argument(
+        "--output-json",
+        "-oJ",
+        help=("Save enumeration output to JSON file."),
+        metavar="JSON_FILE",
+        type=StringType(256),
     )

--- a/gatox/cli/app/config.py
+++ b/gatox/cli/app/config.py
@@ -1,0 +1,114 @@
+from gatox.cli.output import Fore, Style, Output
+from gatox.util.arg_utils import StringType, ReadableFile
+
+
+def configure_parser_app(parser):
+    """Helper method to add arguments to the app subparser.
+
+    Args:
+        parser: sub parser to add arguments to.
+    """
+
+    # Add general arguments
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="CRITICAL",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--socks-proxy",
+        "-sp",
+        help=(
+            "SOCKS proxy to use for requests, in"
+            f" {Fore.GREEN}HOST{Style.RESET_ALL}:{Fore.GREEN}PORT"
+            f" {Style.RESET_ALL}format"
+        ),
+        required=False,
+    )
+
+    parser.add_argument(
+        "--http-proxy",
+        help=(
+            "HTTPS proxy to use for requests, in"
+            f" {Fore.GREEN}HOST{Style.RESET_ALL}:{Fore.GREEN}PORT"
+            f" {Style.RESET_ALL}format."
+        ),
+        required=False,
+    )
+
+    parser.add_argument(
+        "--no-color", "-nc", help="Removes all color from output.", action="store_true"
+    )
+
+    parser.add_argument(
+        "--app",
+        "-a",
+        help="GitHub App ID to authenticate with.",
+        metavar=f"{Fore.RED}APP_ID{Style.RESET_ALL}",
+        type=int,
+        required=True,
+    )
+
+    parser.add_argument(
+        "--pem",
+        help="Path to the GitHub App private key PEM file.",
+        metavar=f"{Fore.RED}PATH/TO/PRIVATE_KEY.pem{Style.RESET_ALL}",
+        type=ReadableFile(),
+        required=True,
+    )
+
+    # Create mutually exclusive group for the different operation modes
+    operation_group = parser.add_mutually_exclusive_group(required=True)
+
+    operation_group.add_argument(
+        "--installations",
+        "-i",
+        help="List all app installations with metadata including repositories and permissions.",
+        action="store_true",
+    )
+
+    operation_group.add_argument(
+        "--full",
+        "-f",
+        help="Perform full enumeration on all maximally visible repositories across all installations.",
+        action="store_true",
+    )
+
+    operation_group.add_argument(
+        "--installation",
+        "-I",
+        help="Enumerate a specific installation by ID.",
+        metavar=f"{Fore.RED}INSTALLATION_ID{Style.RESET_ALL}",
+        type=int,
+    )
+
+    parser.add_argument(
+        "--output-json",
+        "-oJ",
+        help="Save enumeration output to JSON file.",
+        metavar="JSON_FILE",
+        type=StringType(256),
+    )
+
+    parser.add_argument(
+        "--skip-runners",
+        "-sr",
+        help=(
+            f"Do {Output.bright('NOT')} enumerate runners via run-log analysis, this will\n"
+            "speed up the enumeration, but will miss self-hosted runners for\n"
+            "non-admin users."
+        ),
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--deep-dive",
+        "-dd",
+        help=(
+            "Perform deep dive static analysis, which includes analyzing non-default branches for Pwn Request vulnerabilities.\n"
+            "Git is required on the PATH for this feature."
+        ),
+        action="store_true",
+    )

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -114,12 +114,7 @@ def validate_arguments(args, parser):
     # App command has different authentication requirements
     if hasattr(args, "app") and args.app is not None:
         # App command uses App ID + PEM file instead of GH_TOKEN
-        args_dict = vars(args)
-        args_dict["gh_token"] = None  # App command doesn't use this
-    elif "GH_TOKEN" not in os.environ:
-        gh_token = input(
-            "No 'GH_TOKEN' environment variable set! Please enter a GitHub PAT.\n"
-        )
+        gh_token = None  # App command doesn't use this
     else:
         # Regular commands need GH_TOKEN
         if "GH_TOKEN" not in os.environ:

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -14,7 +14,9 @@ from gatox.caching.local_cache_manager import LocalCacheFactory
 from gatox.cli.enumeration.config import configure_parser_enumerate
 from gatox.cli.search.config import configure_parser_search
 from gatox.cli.attack.config import configure_parser_attack
+from gatox.cli.app.config import configure_parser_app
 from gatox.enumerate.enumerate import Enumerator
+from gatox.enumerate.app_enumerate import AppEnumerator
 from gatox.attack.attack import Attacker
 from gatox.attack.runner.webshell import WebShell
 from gatox.attack.secrets.secrets_attack import SecretsAttack
@@ -73,9 +75,17 @@ async def cli(args):
     )
     search_parser.set_defaults(func=search)
 
+    app_parser = subparsers.add_parser(
+        "app",
+        help="GitHub App Enumeration Capabilities",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    app_parser.set_defaults(func=app)
+
     configure_parser_attack(attack_parser)
     configure_parser_enumerate(enumerate_parser)
     configure_parser_search(search_parser)
+    configure_parser_app(app_parser)
 
     arguments = parser.parse_args(args)
 
@@ -101,37 +111,47 @@ def save_workflow_ymls(output_directory):
 def validate_arguments(args, parser):
     logging.basicConfig(level=args.log_level)
 
-    if "GH_TOKEN" not in os.environ:
-        gh_token = input(
-            "No 'GH_TOKEN' environment variable set! Please enter a GitHub" " PAT.\n"
-        )
+    # App command has different authentication requirements
+    if hasattr(args, "app") and args.app is not None:
+        # App command uses App ID + PEM file instead of GH_TOKEN
+        args_dict = vars(args)
+        args_dict["gh_token"] = None  # App command doesn't use this
     else:
-        gh_token = os.environ["GH_TOKEN"]
-
-    if "github_pat_" in gh_token:
-        parser.error(f"{Fore.RED}[!] Fine-grained PATs are currently not supported!")
-
-    if not (
-        re.match("gh[po]_[A-Za-z0-9]{36}$", gh_token)
-        or re.match("^[a-fA-F0-9]{40}$", gh_token)
-    ):
-        if re.match("gh[s]_[A-Za-z0-9]{36}$", gh_token):
-            if not (args.machine and args.repository):
-                parser.error(
-                    f"{Fore.RED}[!]{Style.RESET_ALL} Gato-X does"
-                    " not support App tokens without machine flag."
-                )
-            else:
-                Output.info(
-                    "Allowing the use of a GitHub App token for single repo enumeration."
-                )
+        # Regular commands need GH_TOKEN
+        if "GH_TOKEN" not in os.environ:
+            gh_token = input(
+                "No 'GH_TOKEN' environment variable set! Please enter a GitHub"
+                " PAT.\n"
+            )
         else:
+            gh_token = os.environ["GH_TOKEN"]
+
+        if "github_pat_" in gh_token:
             parser.error(
-                f"{Fore.RED}[!]{Style.RESET_ALL} Provided GitHub PAT is malformed or unsupported!"
+                f"{Fore.RED}[!] Fine-grained PATs are currently not supported!"
             )
 
-    args_dict = vars(args)
-    args_dict["gh_token"] = gh_token
+        if not (
+            re.match("gh[po]_[A-Za-z0-9]{36}$", gh_token)
+            or re.match("^[a-fA-F0-9]{40}$", gh_token)
+        ):
+            if re.match("gh[s]_[A-Za-z0-9]{36}$", gh_token):
+                if not (args.machine and args.repository):
+                    parser.error(
+                        f"{Fore.RED}[!]{Style.RESET_ALL} Gato-X does"
+                        " not support App tokens without machine flag."
+                    )
+                else:
+                    Output.info(
+                        "Allowing the use of a GitHub App token for single repo enumeration."
+                    )
+            else:
+                parser.error(
+                    f"{Fore.RED}[!]{Style.RESET_ALL} Provided GitHub PAT is malformed or unsupported!"
+                )
+
+        args_dict = vars(args)
+        args_dict["gh_token"] = gh_token
 
     if args.socks_proxy and args.http_proxy:
         parser.error(
@@ -411,6 +431,84 @@ async def search(args, parser):
 
     if results:
         gh_search_runner.present_results(results, args.output_text)
+
+
+async def app(args, parser):
+    """Handler for the app command."""
+    parser = parser.choices["app"]
+
+    # Create the app enumerator
+    app_enumerator = AppEnumerator(
+        app_id=args.app,
+        private_key_path=args.pem,
+        socks_proxy=args.socks_proxy,
+        http_proxy=args.http_proxy,
+        skip_log=args.skip_runners,
+        github_url=args.api_url,
+        deep_dive=args.deep_dive,
+    )
+
+    exec_wrapper = Execution()
+
+    try:
+        if args.installations:
+            # List all installations with metadata
+            installations = await app_enumerator.list_installations()
+            if installations:
+                Output.result(f"Found {len(installations)} installation(s)")
+                for installation in installations:
+                    Output.info(f"Installation ID: {installation['id']}")
+                    Output.tabbed(f"Account: {installation['account']['login']}")
+                    Output.tabbed(f"App ID: {installation['app_id']}")
+                    Output.tabbed(f"Permissions: {installation.get('permissions', {})}")
+                    if "repositories" in installation:
+                        Output.tabbed(
+                            f"Repositories: {len(installation['repositories'])}"
+                        )
+                        for repo in installation["repositories"][:5]:  # Show first 5
+                            Output.tabbed(f"  - {repo['full_name']}")
+                        if len(installation["repositories"]) > 5:
+                            Output.tabbed(
+                                f"  ... and {len(installation['repositories']) - 5} more"
+                            )
+                    Output.print("")
+            else:
+                Output.warn("No installations found")
+
+        elif args.installation:
+            # Enumerate specific installation
+            installation_data = await app_enumerator.enumerate_installation(
+                args.installation
+            )
+            if installation_data:
+                Output.result(
+                    f"Successfully enumerated installation {args.installation}"
+                )
+                exec_wrapper.add_repositories(installation_data.get("repositories", []))
+            else:
+                Output.error(f"Failed to enumerate installation {args.installation}")
+
+        elif args.full:
+            # Full enumeration across all installations
+            orgs, repos = await app_enumerator.enumerate_all_installations()
+            if orgs or repos:
+                Output.result("Full enumeration completed successfully")
+                exec_wrapper.add_organizations(orgs)
+                exec_wrapper.add_repositories(repos)
+            else:
+                Output.warn("No data found during full enumeration")
+
+        # Save output if requested
+        if args.output_json:
+            try:
+                Output.write_json(exec_wrapper, args.output_json)
+            except Exception as output_error:
+                Output.error(
+                    "Encountered an error writing the output JSON, this is likely a Gato-X bug."
+                )
+
+    except Exception as e:
+        Output.error(f"App enumeration failed: {str(e)}")
 
 
 def configure_parser_general(parser):

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -77,7 +77,7 @@ async def cli(args):
 
     app_parser = subparsers.add_parser(
         "app",
-        help=f"{Output.red("[Experimental]")} GitHub App Enumeration Capabilities",
+        help=f"{Output.red('[Experimental]')} GitHub App Enumeration Capabilities",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     app_parser.set_defaults(func=app)

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -28,10 +28,10 @@ async def cli(args):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
         description=(
-            f"{Fore.YELLOW}This tool requires a GitHub PAT to"
+            f"{Fore.YELLOW}This tool requires a GitHub access token to"
             f" function!{Style.RESET_ALL}\n\nThis can be passed via the"
             ' "GH_TOKEN" environment variable, or if it is not set,\nthen the'
-            " application will prompt you for one."
+            " application will prompt you for one. App enumeration requires a GitHub App ID and PEM file.\n\n"
         ),
     )
 
@@ -43,7 +43,7 @@ async def cli(args):
         "--api-url",
         "-u",
         help=(
-            f"{Fore.RED}{Output.bright('!! Experimental !!')}\n"
+            f"{Fore.RED}{Output.bright('[Experimental]')}\n"
             "Github API URL to target. \n"
             "Defaults to 'https://api.github.com'"
         ),
@@ -77,7 +77,7 @@ async def cli(args):
 
     app_parser = subparsers.add_parser(
         "app",
-        help="GitHub App Enumeration Capabilities",
+        help=f"{Output.red("[Experimental]")} GitHub App Enumeration Capabilities",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     app_parser.set_defaults(func=app)

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -154,8 +154,8 @@ def validate_arguments(args, parser):
                     f"{Fore.RED}[!]{Style.RESET_ALL} Provided GitHub PAT is malformed or unsupported!"
                 )
 
-        args_dict = vars(args)
-        args_dict["gh_token"] = gh_token
+    args_dict = vars(args)
+    args_dict["gh_token"] = gh_token
 
     if args.socks_proxy and args.http_proxy:
         parser.error(

--- a/gatox/enumerate/app_enumerate.py
+++ b/gatox/enumerate/app_enumerate.py
@@ -1,0 +1,199 @@
+import asyncio
+import logging
+from typing import List, Dict, Any, Optional
+
+from gatox.github.api import Api
+from gatox.github.app_auth import GitHubAppAuth
+from gatox.cli.output import Output
+from gatox.enumerate.enumerate import Enumerator
+from gatox.models.execution import Execution
+
+logger = logging.getLogger(__name__)
+
+
+class AppEnumerator:
+    """Handles GitHub App enumeration capabilities."""
+
+    def __init__(
+        self,
+        app_id: str,
+        private_key_path: str,
+        socks_proxy: str = None,
+        http_proxy: str = None,
+        github_url: str = "https://api.github.com",
+        skip_log: bool = True,
+        ignore_workflow_run: bool = False,
+        deep_dive: bool = False,
+    ):
+        """Initialize App Enumerator.
+
+        Args:
+            app_id: GitHub App ID
+            private_key_path: Path to private key PEM file
+            socks_proxy: SOCKS proxy configuration
+            http_proxy: HTTP proxy configuration
+            github_url: GitHub API URL
+            skip_log: Skip runner log analysis
+            ignore_workflow_run: Ignore workflow_run triggers
+            deep_dive: Perform deep dive analysis
+        """
+        self.app_id = app_id
+        self.private_key_path = private_key_path
+        self.socks_proxy = socks_proxy
+        self.http_proxy = http_proxy
+        self.github_url = github_url
+        self.skip_log = skip_log
+        self.ignore_workflow_run = ignore_workflow_run
+        self.deep_dive = deep_dive
+
+        # Initialize App authentication
+        self.app_auth = GitHubAppAuth(app_id, private_key_path)
+
+        # This will be set when we generate the JWT
+        self.api = None
+        self.user_perms = None
+
+    async def _initialize_api_with_jwt(self):
+        """Initialize API with JWT token."""
+        jwt_token = self.app_auth.generate_jwt()
+        self.api = Api(
+            jwt_token,
+            socks_proxy=self.socks_proxy,
+            http_proxy=self.http_proxy,
+            github_url=self.github_url,
+        )
+
+    async def validate_app(self) -> Dict[str, Any]:
+        """Validate the GitHub App and return basic information."""
+        if not self.api:
+            await self._initialize_api_with_jwt()
+
+        app_info = await self.api.get_app_info()
+        if not app_info:
+            raise ValueError(
+                "Failed to validate GitHub App - check App ID and private key"
+            )
+
+        Output.info(f"Successfully authenticated as GitHub App: {app_info['name']}")
+        Output.info(f"App ID: {app_info['id']}")
+        Output.info(f"Owner: {app_info['owner']['login']}")
+
+        return app_info
+
+    async def list_installations(self) -> List[Dict[str, Any]]:
+        """List all installations for the GitHub App."""
+        if not self.api:
+            await self._initialize_api_with_jwt()
+
+        installations = await self.api.get_app_installations()
+        if not installations:
+            Output.error("No installations found or failed to retrieve installations")
+            return []
+
+        Output.info(f"Found {len(installations)} installation(s)")
+
+        enhanced_installations = []
+        for installation in installations:
+            # Get detailed installation info
+            install_info = await self.api.get_installation_info(installation["id"])
+            if install_info:
+                # Get repositories for this installation
+                repos_info = await self.api.get_installation_repositories(
+                    installation["id"]
+                )
+                install_info["accessible_repositories"] = repos_info
+                enhanced_installations.append(install_info)
+            else:
+                enhanced_installations.append(installation)
+
+        return enhanced_installations
+
+    async def enumerate_installation(self, installation_id: str) -> Optional[Execution]:
+        """Enumerate a specific installation."""
+        if not self.api:
+            await self._initialize_api_with_jwt()
+
+        Output.info(f"Enumerating installation {installation_id}")
+
+        # Get installation access token
+        access_token_response = await self.api.get_installation_access_token(
+            installation_id
+        )
+        if not access_token_response:
+            Output.error(
+                f"Failed to get access token for installation {installation_id}"
+            )
+            return None
+
+        # Create new API instance with installation token
+        installation_token = access_token_response["token"]
+        installation_api = Api(
+            installation_token,
+            socks_proxy=self.socks_proxy,
+            http_proxy=self.http_proxy,
+            github_url=self.github_url,
+        )
+
+        # Get installation repositories
+        installation_repos = await installation_api.get_installation_repos()
+        if not installation_repos:
+            Output.error(f"No repositories found for installation {installation_id}")
+            return None
+
+        Output.info(
+            f"Found {installation_repos['total_count']} repositories in installation"
+        )
+
+        # Create standard enumerator with installation token
+        enumerator = Enumerator(
+            installation_token,
+            socks_proxy=self.socks_proxy,
+            http_proxy=self.http_proxy,
+            skip_log=self.skip_log,
+            github_url=self.github_url,
+            ignore_workflow_run=self.ignore_workflow_run,
+            deep_dive=self.deep_dive,
+        )
+
+        # Enumerate repositories
+        repos_to_enumerate = [
+            repo["full_name"] for repo in installation_repos["repositories"]
+        ]
+        enumerated_repos = await enumerator.enumerate_repos(repos_to_enumerate)
+
+        # Create execution wrapper
+        exec_wrapper = Execution()
+        exec_wrapper.set_user_details(enumerator.user_perms)
+        exec_wrapper.add_repositories(enumerated_repos)
+
+        await installation_api.close()
+
+        return exec_wrapper
+
+    async def enumerate_all_installations(self) -> List[Execution]:
+        """Enumerate all installations accessible to the GitHub App."""
+        installations = await self.list_installations()
+
+        results = []
+        for installation in installations:
+            installation_id = installation["id"]
+            Output.info(
+                f"Enumerating installation {installation_id} ({installation.get('account', {}).get('login', 'Unknown')})"
+            )
+
+            try:
+                result = await self.enumerate_installation(str(installation_id))
+                if result:
+                    results.append(result)
+            except Exception as e:
+                Output.error(
+                    f"Failed to enumerate installation {installation_id}: {str(e)}"
+                )
+                continue
+
+        return results
+
+    async def close(self):
+        """Close API connections."""
+        if self.api:
+            await self.api.close()

--- a/gatox/enumerate/app_enumerate.py
+++ b/gatox/enumerate/app_enumerate.py
@@ -74,7 +74,9 @@ class AppEnumerator:
                 "Failed to validate GitHub App - check App ID and private key"
             )
 
-        self.__app_permissions = [f"{k}:{v}" for k, v in app_info["permissions"].items()]
+        self.__app_permissions = [
+            f"{k}:{v}" for k, v in app_info["permissions"].items()
+        ]
 
         Output.info(f"Successfully authenticated as GitHub App: {app_info['name']}")
         Output.info(f"App ID: {app_info['id']}")
@@ -135,7 +137,10 @@ class AppEnumerator:
         if not self.api:
             await self._initialize_api_with_jwt()
 
-        if "contents:read" not in self.__app_permissions and "contents:write" not in self.__app_permissions:
+        if (
+            "contents:read" not in self.__app_permissions
+            and "contents:write" not in self.__app_permissions
+        ):
             Output.error(
                 "App does not have contents permissions, cannot enumerate repositories"
             )

--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -40,6 +40,7 @@ class Enumerator:
         output_json: str = None,
         ignore_workflow_run: bool = False,
         deep_dive: bool = False,
+        app_permisions: list = None,
     ):
         """Initialize enumeration class with arguments sent by user.
 
@@ -53,6 +54,13 @@ class Enumerator:
             downloaded.
             output_json (str, optional): JSON file to output enumeration
             results.
+            ignore_workflow_run (bool, optional): If set, then
+            "workflow_run" triggers will be ignored.
+            deep_dive (bool, optional): If set, then deep dive workflow
+            ingestion will be performed. This will slow down enumeration
+            significantly, but will provide more information about workflows
+            and their runs.
+            app_permissions (list, optional): List of permissions for GitHub App.
         """
         self.api = Api(
             pat,
@@ -69,6 +77,7 @@ class Enumerator:
         self.output_json = output_json
         self.deep_dive = deep_dive
         self.ignore_workflow_run = ignore_workflow_run
+        self.app_permissions = app_permisions
 
         self.repo_e = RepositoryEnum(self.api, skip_log)
         self.org_e = OrganizationEnum(self.api)
@@ -81,12 +90,9 @@ class Enumerator:
             if installation_info:
                 count = installation_info["total_count"]
                 if count > 0:
-                    Output.info(
-                        "Gato-X is using valid a GitHub App installation token!"
-                    )
                     self.user_perms = {
                         "user": "Github App",
-                        "scopes": [],
+                        "scopes": self.app_permissions or [],
                         "name": "GATO-X App Mode",
                     }
 

--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -1819,3 +1819,42 @@ class Api:
 
             if pr_info["merged"]:
                 return pr_info["mergedAt"]
+
+    async def get_app_installations(self):
+        """Get all installations for the GitHub App."""
+        response = await self.call_get("/app/installations")
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+    async def get_installation_access_token(self, installation_id: str):
+        """Get an access token for a specific installation."""
+        response = await self.call_post(
+            f"/app/installations/{installation_id}/access_tokens"
+        )
+        if response.status_code == 201:
+            return response.json()
+        return None
+
+    async def get_installation_info(self, installation_id: str):
+        """Get detailed information about a specific installation."""
+        response = await self.call_get(f"/app/installations/{installation_id}")
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+    async def get_installation_repositories(self, installation_id: str):
+        """Get repositories accessible to a specific installation."""
+        response = await self.call_get(
+            f"/app/installations/{installation_id}/repositories"
+        )
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+    async def get_app_info(self):
+        """Get information about the GitHub App."""
+        response = await self.call_get("/app")
+        if response.status_code == 200:
+            return response.json()
+        return None

--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -37,6 +37,7 @@ class Api:
         socks_proxy: str = None,
         github_url: str = "https://api.github.com",
         client: httpx.AsyncClient = None,  # Optional, mostly for unit tests.
+        app_permissions: list = None,  # Optional, for GitHub App tokens
     ):
         """Initialize the API abstraction layer to interact with the GitHub
         REST API.
@@ -92,6 +93,7 @@ class Api:
                 follow_redirects=True,
                 timeout=30.0,
             )
+        self.app_permissions = app_permissions
 
     async def __aenter__(self):
         return self

--- a/gatox/github/app_auth.py
+++ b/gatox/github/app_auth.py
@@ -1,9 +1,7 @@
-import time
 import jwt
 import logging
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/gatox/github/app_auth.py
+++ b/gatox/github/app_auth.py
@@ -1,0 +1,69 @@
+import time
+import jwt
+import logging
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubAppAuth:
+    """Handles GitHub App authentication and JWT generation."""
+
+    def __init__(self, app_id: str, private_key_path: str):
+        """Initialize GitHub App authentication.
+
+        Args:
+            app_id: The GitHub App ID
+            private_key_path: Path to the private key PEM file
+        """
+        self.app_id = app_id
+        self.private_key_path = Path(private_key_path)
+        self._private_key = None
+
+    def _load_private_key(self) -> str:
+        """Load the private key from file."""
+        if self._private_key is None:
+            if not self.private_key_path.exists():
+                raise FileNotFoundError(
+                    f"Private key file not found: {self.private_key_path}"
+                )
+
+            with open(self.private_key_path, "r") as f:
+                self._private_key = f.read()
+
+        return self._private_key
+
+    def generate_jwt(self, expiration_minutes: int = 10) -> str:
+        """Generate a JWT for GitHub App authentication.
+
+        Args:
+            expiration_minutes: JWT expiration time in minutes (max 10)
+
+        Returns:
+            The generated JWT token
+        """
+        if expiration_minutes > 10:
+            raise ValueError("JWT expiration cannot exceed 10 minutes")
+
+        # Get current time
+        now = datetime.now(timezone.utc)
+
+        # JWT payload
+        payload = {
+            "iat": int(now.timestamp()),  # Issued at time
+            "exp": int(
+                (now + timedelta(minutes=expiration_minutes)).timestamp()
+            ),  # Expiration time
+            "iss": self.app_id,  # Issuer (App ID)
+        }
+
+        # Load private key
+        private_key = self._load_private_key()
+
+        # Generate JWT
+        token = jwt.encode(payload, private_key, algorithm="RS256")
+
+        logger.debug(f"Generated JWT for App ID {self.app_id}")
+        return token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "httpx[socks,http2]",
     "pyyaml",
     "cryptography",
-    "networkx"
+    "networkx",
+    "PyJWT[crypto]"
 ]
 
 [project.optional-dependencies]

--- a/unit_test/test_app_enum.py
+++ b/unit_test/test_app_enum.py
@@ -432,11 +432,14 @@ class TestAppEnumerator:
         """Test enumerate_installation fails when app lacks contents permissions."""
         # Setup API mock
         mock_api_instance = AsyncMock()
-        
+
         # Create enumerator with no contents permissions
         enumerator = AppEnumerator("12345", "/path/to/key.pem")
         enumerator.api = mock_api_instance
-        enumerator._AppEnumerator__app_permissions = ["metadata:read", "actions:read"]  # No contents permission
+        enumerator._AppEnumerator__app_permissions = [
+            "metadata:read",
+            "actions:read",
+        ]  # No contents permission
 
         # Call method
         result = await enumerator.enumerate_installation("11111")
@@ -452,14 +455,16 @@ class TestAppEnumerator:
     @pytest.mark.asyncio
     @patch("gatox.cli.output.Output.info")
     @patch("gatox.cli.output.Output.error")
-    async def test_enumerate_installation_with_contents_read_permission(self, mock_error, mock_info):
+    async def test_enumerate_installation_with_contents_read_permission(
+        self, mock_error, mock_info
+    ):
         """Test enumerate_installation succeeds with contents:read permission."""
         # Setup mocks
         mock_api_instance = AsyncMock()
         mock_api_instance.get_installation_access_token = AsyncMock(
             return_value=MOCK_ACCESS_TOKEN
         )
-        
+
         mock_installation_api = AsyncMock()
         mock_installation_api.get_installation_repos = AsyncMock(
             return_value={
@@ -477,28 +482,37 @@ class TestAppEnumerator:
             # Create enumerator with contents:read permission
             enumerator = AppEnumerator("12345", "/path/to/key.pem")
             enumerator.api = mock_api_instance
-            enumerator._AppEnumerator__app_permissions = ["contents:read", "metadata:read"]
+            enumerator._AppEnumerator__app_permissions = [
+                "contents:read",
+                "metadata:read",
+            ]
 
-            with patch("gatox.enumerate.app_enumerate.Api", return_value=mock_installation_api):
+            with patch(
+                "gatox.enumerate.app_enumerate.Api", return_value=mock_installation_api
+            ):
                 # Call method
                 result = await enumerator.enumerate_installation("11111")
 
                 # Verify success - just check that we got past the permission check
                 assert result is not None
-                mock_api_instance.get_installation_access_token.assert_called_once_with("11111")
+                mock_api_instance.get_installation_access_token.assert_called_once_with(
+                    "11111"
+                )
                 # Don't assert mock_error.assert_not_called() since there might be other validation errors
 
     @pytest.mark.asyncio
     @patch("gatox.cli.output.Output.info")
     @patch("gatox.cli.output.Output.error")
-    async def test_enumerate_installation_with_contents_write_permission(self, mock_error, mock_info):
+    async def test_enumerate_installation_with_contents_write_permission(
+        self, mock_error, mock_info
+    ):
         """Test enumerate_installation succeeds with contents:write permission."""
         # Setup mocks
         mock_api_instance = AsyncMock()
         mock_api_instance.get_installation_access_token = AsyncMock(
             return_value=MOCK_ACCESS_TOKEN
         )
-        
+
         mock_installation_api = AsyncMock()
         mock_installation_api.get_installation_repos = AsyncMock(
             return_value={
@@ -516,15 +530,22 @@ class TestAppEnumerator:
             # Create enumerator with contents:write permission
             enumerator = AppEnumerator("12345", "/path/to/key.pem")
             enumerator.api = mock_api_instance
-            enumerator._AppEnumerator__app_permissions = ["contents:write", "metadata:read"]
+            enumerator._AppEnumerator__app_permissions = [
+                "contents:write",
+                "metadata:read",
+            ]
 
-            with patch("gatox.enumerate.app_enumerate.Api", return_value=mock_installation_api):
+            with patch(
+                "gatox.enumerate.app_enumerate.Api", return_value=mock_installation_api
+            ):
                 # Call method
                 result = await enumerator.enumerate_installation("11111")
 
                 # Verify success - just check that we got past the permission check
                 assert result is not None
-                mock_api_instance.get_installation_access_token.assert_called_once_with("11111")
+                mock_api_instance.get_installation_access_token.assert_called_once_with(
+                    "11111"
+                )
                 # Don't assert mock_error.assert_not_called() since there might be other validation errors
 
     @pytest.mark.asyncio
@@ -534,7 +555,7 @@ class TestAppEnumerator:
         # Setup API mock
         mock_api_instance = AsyncMock()
         mock_api_instance.get_installation_access_token = AsyncMock(return_value=None)
-        
+
         # Create enumerator with proper permissions
         enumerator = AppEnumerator("12345", "/path/to/key.pem")
         enumerator.api = mock_api_instance
@@ -553,14 +574,16 @@ class TestAppEnumerator:
     @pytest.mark.asyncio
     @patch("gatox.cli.output.Output.info")
     @patch("gatox.cli.output.Output.error")
-    async def test_enumerate_installation_no_repositories_found(self, mock_error, mock_info):
+    async def test_enumerate_installation_no_repositories_found(
+        self, mock_error, mock_info
+    ):
         """Test enumerate_installation fails when no repositories found."""
         # Setup mocks
         mock_api_instance = AsyncMock()
         mock_api_instance.get_installation_access_token = AsyncMock(
             return_value=MOCK_ACCESS_TOKEN
         )
-        
+
         mock_installation_api = AsyncMock()
         mock_installation_api.get_installation_repos = AsyncMock(return_value=None)
         mock_installation_api.close = AsyncMock()
@@ -570,7 +593,9 @@ class TestAppEnumerator:
         enumerator.api = mock_api_instance
         enumerator._AppEnumerator__app_permissions = ["contents:read", "metadata:read"]
 
-        with patch("gatox.enumerate.app_enumerate.Api", return_value=mock_installation_api):
+        with patch(
+            "gatox.enumerate.app_enumerate.Api", return_value=mock_installation_api
+        ):
             # Call method
             result = await enumerator.enumerate_installation("11111")
 
@@ -579,14 +604,18 @@ class TestAppEnumerator:
             mock_error.assert_called_with(
                 "No repositories found for installation 11111"
             )
-            mock_api_instance.get_installation_access_token.assert_called_once_with("11111")
+            mock_api_instance.get_installation_access_token.assert_called_once_with(
+                "11111"
+            )
             mock_installation_api.get_installation_repos.assert_called_once()
 
     @pytest.mark.asyncio
     @patch("gatox.github.api.Api")
     @patch("gatox.cli.output.Output.info")
     @patch("gatox.cli.output.Output.yellow")
-    async def test_validate_app_success_with_permissions_parsing(self, mock_yellow, mock_info, mock_api):
+    async def test_validate_app_success_with_permissions_parsing(
+        self, mock_yellow, mock_info, mock_api
+    ):
         """Test successful app validation with permissions parsing."""
         # Setup mocks
         mock_api_instance = MagicMock()
@@ -602,7 +631,7 @@ class TestAppEnumerator:
         # Verify permissions were parsed correctly
         expected_permissions = ["contents:read", "metadata:read", "actions:write"]
         assert enumerator._AppEnumerator__app_permissions == expected_permissions
-        
+
         # Verify result
         assert isinstance(result, dict)
         assert result == MOCK_APP_INFO
@@ -620,7 +649,10 @@ class TestAppEnumerator:
         enumerator = AppEnumerator("12345", "/path/to/key.pem")
         enumerator.api = mock_api_instance
 
-        with pytest.raises(ValueError, match="Failed to validate GitHub App - check App ID and private key"):
+        with pytest.raises(
+            ValueError,
+            match="Failed to validate GitHub App - check App ID and private key",
+        ):
             await enumerator.validate_app()
 
         mock_api_instance.get_app_info.assert_called_once()
@@ -644,14 +676,14 @@ class TestAppEnumeratorPermissionChecks:
                 "App does not have contents permissions, cannot enumerate repositories"
             )
 
-    @pytest.mark.asyncio 
+    @pytest.mark.asyncio
     async def test_enumerate_installation_none_permissions(self):
         """Test enumerate_installation with None permissions."""
         enumerator = AppEnumerator("12345", "/path/to/key.pem")
         enumerator.api = AsyncMock()
         enumerator._AppEnumerator__app_permissions = None  # None permissions
 
-        with patch("gatox.cli.output.Output.error") as mock_error:
+        with patch("gatox.cli.output.Output.error"):
             # This should raise an AttributeError because 'in' operator can't work on None
             with pytest.raises(TypeError):
                 await enumerator.enumerate_installation("11111")
@@ -662,11 +694,11 @@ class TestAppEnumeratorPermissionChecks:
         enumerator = AppEnumerator("12345", "/path/to/key.pem")
         enumerator.api = AsyncMock()
         enumerator._AppEnumerator__app_permissions = [
-            "metadata:read", 
-            "issues:write", 
+            "metadata:read",
+            "issues:write",
             "pull_requests:read",
             "actions:read",
-            "checks:write"
+            "checks:write",
         ]
 
         with patch("gatox.cli.output.Output.error") as mock_error:
@@ -685,7 +717,7 @@ class TestAppEnumeratorPermissionChecks:
         mock_api_instance.get_installation_access_token = AsyncMock(
             return_value=MOCK_ACCESS_TOKEN
         )
-        
+
         mock_installation_api = AsyncMock()
         mock_installation_api.get_installation_repos = AsyncMock(
             return_value={
@@ -703,7 +735,10 @@ class TestAppEnumeratorPermissionChecks:
             # Create enumerator with contents:admin permission (should fail since it's not read/write)
             enumerator = AppEnumerator("12345", "/path/to/key.pem")
             enumerator.api = mock_api_instance
-            enumerator._AppEnumerator__app_permissions = ["contents:admin", "metadata:read"]
+            enumerator._AppEnumerator__app_permissions = [
+                "contents:admin",
+                "metadata:read",
+            ]
 
             with patch("gatox.cli.output.Output.error") as mock_error:
                 result = await enumerator.enumerate_installation("11111")

--- a/unit_test/test_app_enum.py
+++ b/unit_test/test_app_enum.py
@@ -1,23 +1,17 @@
 import os
-import pathlib
 import pytest
-import json
 import httpx
 import tempfile
-import jwt
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from unittest.mock import patch, AsyncMock, MagicMock, mock_open
 
 # Import pytest-asyncio for async test support
-import pytest_asyncio
 
-from gatox.github.api import Api
 from gatox.github.app_auth import GitHubAppAuth
 from gatox.enumerate.app_enumerate import AppEnumerator
 from gatox.cli.output import Output
 from gatox.models.execution import Execution
 
-from unit_test.utils import escape_ansi
 
 # Initialize output for testing
 Output(True)
@@ -318,7 +312,7 @@ class TestAppEnumerator:
         enumerator.api = mock_api_instance
 
         # Call the enumerate_installation method and ensure it completes
-        result = await enumerator.enumerate_installation(11111)
+        await enumerator.enumerate_installation(11111)
 
         # Verify the API token was requested
         mock_api_instance.get_installation_access_token.assert_called_once_with(11111)
@@ -374,7 +368,8 @@ class TestAppEnumerator:
         mock_installation_api.get_installation_repos.assert_called_once()
         mock_enumerator_instance.enumerate_repos.assert_called_once()
         assert result is not None
-        assert isinstance(result, Execution)
+        # The method returns a list of Repository objects, not an Execution object
+        assert isinstance(result, list)
 
     @pytest.mark.asyncio
     @patch("gatox.enumerate.app_enumerate.AppEnumerator.enumerate_installation")

--- a/unit_test/test_app_enum.py
+++ b/unit_test/test_app_enum.py
@@ -1,0 +1,521 @@
+import os
+import pathlib
+import pytest
+import json
+import httpx
+import tempfile
+import jwt
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, AsyncMock, MagicMock, mock_open
+
+# Import pytest-asyncio for async test support
+import pytest_asyncio
+
+from gatox.github.api import Api
+from gatox.github.app_auth import GitHubAppAuth
+from gatox.enumerate.app_enumerate import AppEnumerator
+from gatox.cli.output import Output
+from gatox.models.execution import Execution
+
+from unit_test.utils import escape_ansi
+
+# Initialize output for testing
+Output(True)
+
+# Mock data for testing
+MOCK_PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN
+OPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP
+QRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR
+STUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
+UVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV
+WXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWX
+YZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ12
+-----END RSA PRIVATE KEY-----"""
+
+MOCK_APP_INFO = {
+    "id": 12345,
+    "slug": "test-app",
+    "name": "Test App",
+    "owner": {"login": "test-owner", "id": 67890},
+    "description": "Test GitHub App",
+    "permissions": {"contents": "read", "metadata": "read", "actions": "write"},
+}
+
+MOCK_INSTALLATIONS = [
+    {
+        "id": 11111,
+        "account": {"login": "test-org", "id": 22222, "type": "Organization"},
+        "app_id": 12345,
+        "permissions": {"contents": "read", "metadata": "read", "actions": "write"},
+        "repository_selection": "all",
+    },
+    {
+        "id": 33333,
+        "account": {"login": "test-user", "id": 44444, "type": "User"},
+        "app_id": 12345,
+        "permissions": {"contents": "read", "metadata": "read"},
+        "repository_selection": "selected",
+    },
+]
+
+MOCK_INSTALLATION_REPOS = [
+    {
+        "id": 55555,
+        "name": "test-repo-1",
+        "full_name": "test-org/test-repo-1",
+        "private": False,
+        "permissions": {"admin": False, "push": True, "pull": True},
+    },
+    {
+        "id": 66666,
+        "name": "test-repo-2",
+        "full_name": "test-org/test-repo-2",
+        "private": True,
+        "permissions": {"admin": True, "push": True, "pull": True},
+    },
+]
+
+MOCK_ACCESS_TOKEN = {
+    "token": "ghs_abcdefghijklmnopqrstuvwxyz123456",
+    "expires_at": "2024-01-01T12:00:00Z",
+}
+
+
+class TestGitHubAppAuth:
+    """Test cases for GitHubAppAuth class."""
+
+    def test_init(self):
+        """Test GitHubAppAuth initialization."""
+        app_auth = GitHubAppAuth("12345", "/path/to/key.pem")
+        assert app_auth.app_id == "12345"
+        assert str(app_auth.private_key_path) == "/path/to/key.pem"
+        assert app_auth._private_key is None
+
+    def test_load_private_key_file_not_found(self):
+        """Test private key loading with non-existent file."""
+        app_auth = GitHubAppAuth("12345", "/nonexistent/key.pem")
+
+        with pytest.raises(FileNotFoundError, match="Private key file not found"):
+            app_auth._load_private_key()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_PRIVATE_KEY)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_load_private_key_success(self, mock_exists, mock_file):
+        """Test successful private key loading."""
+        app_auth = GitHubAppAuth("12345", "/path/to/key.pem")
+
+        key = app_auth._load_private_key()
+        assert key == MOCK_PRIVATE_KEY
+        assert app_auth._private_key == MOCK_PRIVATE_KEY
+
+        # Test caching
+        key2 = app_auth._load_private_key()
+        assert key2 == MOCK_PRIVATE_KEY
+        mock_file.assert_called_once()  # Should only be called once due to caching
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_PRIVATE_KEY)
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("jwt.encode")
+    def test_generate_jwt_success(self, mock_jwt_encode, mock_exists, mock_file):
+        """Test successful JWT generation."""
+        mock_jwt_encode.return_value = "mock.jwt.token"
+        app_auth = GitHubAppAuth("12345", "/path/to/key.pem")
+
+        token = app_auth.generate_jwt()
+
+        assert token == "mock.jwt.token"
+        mock_jwt_encode.assert_called_once()
+
+        # Verify JWT payload structure
+        call_args = mock_jwt_encode.call_args
+        payload = call_args[0][0]
+
+        assert payload["iss"] == "12345"
+        assert "iat" in payload
+        assert "exp" in payload
+        assert payload["exp"] > payload["iat"]
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_PRIVATE_KEY)
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_generate_jwt_expiration_too_long(self, mock_exists, mock_file):
+        """Test JWT generation with expiration time too long."""
+        app_auth = GitHubAppAuth("12345", "/path/to/key.pem")
+
+        with pytest.raises(ValueError, match="JWT expiration cannot exceed 10 minutes"):
+            app_auth.generate_jwt(expiration_minutes=15)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_PRIVATE_KEY)
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("jwt.encode")
+    def test_generate_jwt_custom_expiration(
+        self, mock_jwt_encode, mock_exists, mock_file
+    ):
+        """Test JWT generation with custom expiration time."""
+        mock_jwt_encode.return_value = "mock.jwt.token"
+        app_auth = GitHubAppAuth("12345", "/path/to/key.pem")
+
+        token = app_auth.generate_jwt(expiration_minutes=5)
+
+        assert token == "mock.jwt.token"
+        call_args = mock_jwt_encode.call_args
+        payload = call_args[0][0]
+
+        # Verify expiration is approximately 5 minutes from now
+        now = datetime.now(timezone.utc).timestamp()
+        exp_time = payload["exp"]
+        assert abs(exp_time - now - 300) < 10  # Within 10 seconds of 5 minutes
+
+
+class TestAppEnumerator:
+    """Test cases for AppEnumerator class."""
+
+    def test_init(self):
+        """Test AppEnumerator initialization."""
+        enumerator = AppEnumerator(
+            app_id="12345",
+            private_key_path="/path/to/key.pem",
+            socks_proxy="localhost:9050",
+            http_proxy="localhost:8080",
+            github_url="https://github.enterprise.com/api/v3",
+            skip_log=False,
+            ignore_workflow_run=True,
+            deep_dive=True,
+        )
+
+        assert enumerator.app_id == "12345"
+        assert enumerator.private_key_path == "/path/to/key.pem"
+        assert enumerator.socks_proxy == "localhost:9050"
+        assert enumerator.http_proxy == "localhost:8080"
+        assert enumerator.github_url == "https://github.enterprise.com/api/v3"
+        assert enumerator.skip_log is False
+        assert enumerator.ignore_workflow_run is True
+        assert enumerator.deep_dive is True
+        assert isinstance(enumerator.app_auth, GitHubAppAuth)
+
+    @pytest.mark.asyncio
+    @patch("gatox.enumerate.app_enumerate.Api")
+    async def test_initialize_api_with_jwt(self, mock_api_class):
+        """Test API client initialization with JWT."""
+        # Create mocks
+        mock_app_auth = MagicMock()
+        mock_app_auth.generate_jwt.return_value = "mock.jwt.token"
+        mock_api_instance = MagicMock()
+        mock_api_class.return_value = mock_api_instance
+
+        # Create test object
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.app_auth = mock_app_auth
+
+        # Call method
+        await enumerator._initialize_api_with_jwt()
+
+        # Verify JWT was generated and API was created
+        mock_app_auth.generate_jwt.assert_called_once()
+        mock_api_class.assert_called_once()
+        assert mock_api_class.call_args.args[0] == "mock.jwt.token"
+
+    @pytest.mark.asyncio
+    @pytest.mark.asyncio
+    @patch("gatox.github.api.Api")
+    async def test_validate_app_success(self, mock_api):
+        """Test successful app validation."""
+        # Setup mocks
+        mock_api_instance = MagicMock()
+        mock_api_instance.get_app_info = AsyncMock(return_value=MOCK_APP_INFO)
+        mock_api.return_value = mock_api_instance
+
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.api = mock_api_instance
+
+        result = await enumerator.validate_app()
+
+        assert isinstance(result, dict)
+        mock_api_instance.get_app_info.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("gatox.github.api.Api")
+    async def test_validate_app_failure(self, mock_api):
+        """Test app validation failure."""
+        # Setup mocks
+        mock_api_instance = MagicMock()
+        mock_api_instance.get_app_info = AsyncMock(side_effect=Exception("API Error"))
+        mock_api.return_value = mock_api_instance
+
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.api = mock_api_instance
+
+        with pytest.raises(Exception, match="API Error"):
+            await enumerator.validate_app()
+
+    @pytest.mark.asyncio
+    @patch("gatox.github.api.Api")
+    @patch("gatox.cli.output.Output.info")
+    @patch("gatox.cli.output.Output.error")
+    async def test_list_installations(self, mock_error, mock_info, mock_api):
+        """Test listing app installations."""
+        # Setup mocks
+        mock_api_instance = MagicMock()
+        mock_api_instance.get_app_installations = AsyncMock(
+            return_value=MOCK_INSTALLATIONS
+        )
+        mock_api_instance.get_installation_info = AsyncMock(
+            side_effect=lambda id: next(
+                (inst for inst in MOCK_INSTALLATIONS if inst["id"] == id), None
+            )
+        )
+        mock_api_instance.get_installation_repositories = AsyncMock(
+            return_value=MOCK_INSTALLATION_REPOS
+        )
+        mock_api.return_value = mock_api_instance
+
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.api = mock_api_instance
+
+        installations = await enumerator.list_installations()
+
+        assert len(installations) == 2
+        mock_api_instance.get_app_installations.assert_called_once()
+        assert mock_api_instance.get_installation_info.call_count == 2
+        assert mock_api_instance.get_installation_repositories.call_count == 2
+        mock_info.assert_called()
+
+    @pytest.mark.asyncio
+    @patch("gatox.enumerate.enumerate.Enumerator")
+    @patch("gatox.github.api.Api")
+    @patch("gatox.cli.output.Output.info")
+    @patch("gatox.cli.output.Output.error")
+    async def test_enumerate_installation_repositories(
+        self, mock_error, mock_info, mock_api, mock_enumerator_class
+    ):
+        """Test getting repositories for an installation."""
+        # Setup mocks
+        mock_api_instance = MagicMock()
+        mock_api_instance.get_installation_access_token = AsyncMock(
+            return_value=MOCK_ACCESS_TOKEN
+        )
+        mock_api_instance.get_installation_repositories = AsyncMock(
+            return_value=MOCK_INSTALLATION_REPOS
+        )
+        mock_api_instance.get_installation_info = AsyncMock(
+            return_value=MOCK_INSTALLATIONS[0]
+        )
+
+        # For the mock API constructor, return different instances
+        mock_installation_api = MagicMock()
+        mock_api.side_effect = [mock_api_instance, mock_installation_api]
+
+        # Mock enumerator class
+        mock_enumerator_instance = MagicMock()
+        execution_result = Execution()
+        execution_result.repositories = ["test-org/test-repo-1"]
+        mock_enumerator_instance.enumerate = AsyncMock(return_value=execution_result)
+        mock_enumerator_class.return_value = mock_enumerator_instance
+
+        # Create test object
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.api = mock_api_instance
+
+        # Call the enumerate_installation method and ensure it completes
+        result = await enumerator.enumerate_installation(11111)
+
+        # Verify the API token was requested
+        mock_api_instance.get_installation_access_token.assert_called_once_with(11111)
+
+    @pytest.mark.asyncio
+    @patch("gatox.enumerate.app_enumerate.Enumerator")
+    @patch("gatox.cli.output.Output.info")
+    @patch("gatox.cli.output.Output.error")
+    async def test_enumerate_installation(
+        self, mock_error, mock_info, mock_enumerator_class
+    ):
+        """Test enumerating a specific installation."""
+        # Setup mocks for the API
+        mock_api_instance = AsyncMock()
+        mock_api_instance.get_installation_access_token = AsyncMock(
+            return_value=MOCK_ACCESS_TOKEN
+        )
+        mock_api_instance.get_installation_info = AsyncMock(
+            return_value=MOCK_INSTALLATIONS[0]
+        )
+        mock_api_instance.close = AsyncMock()
+
+        # Mock for installation API
+        mock_installation_api = AsyncMock()
+        mock_installation_api.get_installation_repos = AsyncMock(
+            return_value={
+                "total_count": len(MOCK_INSTALLATION_REPOS),
+                "repositories": MOCK_INSTALLATION_REPOS,
+            }
+        )
+        mock_installation_api.close = AsyncMock()
+
+        # Setup mock for Enumerator
+        mock_enumerator_instance = MagicMock()
+        mock_enumerator_instance.enumerate_repos = AsyncMock(
+            return_value=["test-org/test-repo-1", "test-org/test-repo-2"]
+        )
+        mock_enumerator_class.return_value = mock_enumerator_instance
+
+        # Create enumerator with mocked API
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.api = mock_api_instance
+
+        # Patch the Api constructor directly inside the test
+        with patch(
+            "gatox.enumerate.app_enumerate.Api", return_value=mock_installation_api
+        ):
+            # Run test
+            result = await enumerator.enumerate_installation(11111)
+
+        # Verify API calls
+        mock_api_instance.get_installation_access_token.assert_called_once_with(11111)
+        mock_installation_api.get_installation_repos.assert_called_once()
+        mock_enumerator_instance.enumerate_repos.assert_called_once()
+        assert result is not None
+        assert isinstance(result, Execution)
+
+    @pytest.mark.asyncio
+    @patch("gatox.enumerate.app_enumerate.AppEnumerator.enumerate_installation")
+    @patch("gatox.cli.output.Output.info")
+    async def test_enumerate_all_installations(self, mock_info, mock_enum_installation):
+        """Test enumerating all installations."""
+        # Setup mocks with proper AsyncMock methods
+        mock_api_instance = AsyncMock()
+        mock_api_instance.get_app_installations = AsyncMock(
+            return_value=MOCK_INSTALLATIONS
+        )
+        mock_api_instance.get_app_info = AsyncMock(return_value=MOCK_APP_INFO)
+        mock_api_instance.get_installation_info = AsyncMock(
+            return_value=MOCK_INSTALLATIONS[0]
+        )
+        mock_api_instance.get_installation_repositories = AsyncMock(
+            return_value=MOCK_INSTALLATION_REPOS
+        )
+        mock_api_instance.close = AsyncMock()
+
+        # Setup mock for enumerate_installation
+        installation_result1 = Execution()
+        installation_result1.add_repositories(["repo1", "repo2"])
+        installation_result1.set_user_details({"installation_id": 11111})
+
+        installation_result2 = Execution()
+        installation_result2.add_repositories(["repo3"])
+        installation_result2.set_user_details({"installation_id": 33333})
+
+        mock_enum_installation.side_effect = [
+            installation_result1,
+            installation_result2,
+        ]
+
+        # Create enumerator with mocked API
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.api = mock_api_instance
+
+        # We need to patch validate_app to return directly
+        with patch.object(
+            enumerator, "validate_app", AsyncMock(return_value=MOCK_APP_INFO)
+        ):
+            # Run test
+            results = await enumerator.enumerate_all_installations()
+
+        # Verify calls
+        mock_api_instance.get_app_installations.assert_called_once()
+        mock_api_instance.get_installation_repositories.assert_called()
+        assert mock_enum_installation.call_count == 2
+
+        # Verify that results is a list of execution objects
+        assert len(results) == 2
+        assert all(isinstance(result, Execution) for result in results)
+
+
+class TestAppEnumeratorIntegration:
+    """Integration tests for AppEnumerator."""
+
+    def test_real_pem_file_validation(self):
+        """Test with a real temporary PEM file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as f:
+            f.write(MOCK_PRIVATE_KEY)
+            pem_path = f.name
+
+        try:
+            app_auth = GitHubAppAuth("12345", pem_path)
+            key = app_auth._load_private_key()
+            assert key == MOCK_PRIVATE_KEY
+        finally:
+            os.unlink(pem_path)
+
+    @pytest.mark.asyncio
+    @patch("gatox.enumerate.app_enumerate.Api")
+    async def test_app_enumerator_with_real_file(self, mock_api):
+        """Test AppEnumerator with a real temporary PEM file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as f:
+            f.write(MOCK_PRIVATE_KEY)
+            pem_path = f.name
+
+        try:
+            # Create API mock
+            mock_api_instance = MagicMock()
+            mock_api.return_value = mock_api_instance
+
+            # Create and test the enumerator
+            enumerator = AppEnumerator("12345", pem_path)
+
+            # Mock the JWT generation specifically
+            enumerator.app_auth = MagicMock()
+            enumerator.app_auth.generate_jwt.return_value = "mock.jwt.token"
+
+            # Initialize API
+            await enumerator._initialize_api_with_jwt()
+
+            # Verify results
+            enumerator.app_auth.generate_jwt.assert_called_once()
+            mock_api.assert_called_once()
+            assert enumerator.api is mock_api_instance
+        finally:
+            os.unlink(pem_path)
+
+
+class TestAppEnumeratorErrorHandling:
+    """Test error handling in AppEnumerator."""
+
+    @pytest.mark.asyncio
+    async def test_jwt_generation_error(self):
+        """Test handling of JWT generation errors."""
+        # Create a mock GitHubAppAuth that raises an exception
+        mock_app_auth = MagicMock()
+        mock_app_auth.generate_jwt.side_effect = Exception("JWT generation failed")
+
+        # Create enumerator with mocked auth
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.app_auth = mock_app_auth
+
+        # Test exception propagation
+        with pytest.raises(Exception, match="JWT generation failed"):
+            await enumerator._initialize_api_with_jwt()
+
+    @pytest.mark.asyncio
+    @patch("gatox.github.api.Api")
+    @patch("gatox.cli.output.Output.error")
+    async def test_api_error_handling(self, mock_error, mock_api):
+        """Test handling of API errors."""
+        # Setup mock API with error
+        mock_api_instance = MagicMock()
+        mock_api_instance.get_app_installations = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "API Error", request=MagicMock(), response=MagicMock()
+            )
+        )
+        mock_api.return_value = mock_api_instance
+
+        # Create enumerator with mocked API
+        enumerator = AppEnumerator("12345", "/path/to/key.pem")
+        enumerator.api = mock_api_instance
+
+        # Test error handling during list_installations
+        with pytest.raises(httpx.HTTPStatusError):
+            await enumerator.list_installations()
+
+        # Verify error was called
+        mock_api_instance.get_app_installations.assert_called_once()

--- a/unit_test/test_cli.py
+++ b/unit_test/test_cli.py
@@ -95,7 +95,6 @@ async def test_cli_s2s_token_machine(mock_api, capfd):
     await cli.cli(["enumerate", "-r", "testOrg/testRepo", "--machine"])
     out, _ = capfd.readouterr()
     assert "Allowing the use of a GitHub App token for single repo enumeration" in out
-    assert "Gato-X is using valid a GitHub App installation token" in out
 
 
 async def test_cli_u2s_token(capfd):

--- a/unit_test/test_cli.py
+++ b/unit_test/test_cli.py
@@ -36,7 +36,7 @@ def mock_settings_env_vars():
         yield
 
 
-@patch("builtins.input", return_value="")
+@patch("builtins.input", return_value="BAD_TOKEN")
 async def test_cli_no_gh_token(mock_input, capfd):
     """Test case where no GH Token is provided"""
     del os.environ["GH_TOKEN"]


### PR DESCRIPTION
This PR adds initial experimental functionality for App Private key enumeration.

Plan is to support app authentication for all enumeration _and_ attack features with a 1.3 release. This will require an overhaul to the permissions checking module because different features will require a specific set of fine-grained permissions (at minimum).