### PR TITLE
Fix call_get in case of missing response

### DIFF
--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -321,6 +321,7 @@ class Api:
         if strip_auth:
             del get_header["Authorization"]
 
+        api_response = None
         for _ in range(0, 5):
             try:
                 logger.debug(f"Making GET API request to {request_url}!")
@@ -332,9 +333,16 @@ class Api:
                 )
 
                 break
-            except Exception:
-                logger.warning("GET request failed due to transport error re-trying!")
+            except Exception as e:
+                logger.warning(
+                    f"GET request {request_url} failed due to transport error re-trying",
+                    exc_info=e,
+                )
                 continue
+
+        if api_response is None:
+            raise Exception(f"GET request {request_url} failed after 5 attempts")
+
         if not strip_auth:
             await self.__check_rate_limit(api_response.headers)
 


### PR DESCRIPTION
Hi!

I'd like to suggest a quick fix, when testing on an unreliable connection, the `api_response` could be `None` after the 5 tries.

Before logs:

```
Making GET API request to https://api.github.com/repos/slackapi/slack-github-action/environments!
GET request failed due to transport error re-trying!
Making GET API request to https://api.github.com/repos/slackapi/slack-github-action/environments!
GET request failed due to transport error re-trying!
Making GET API request to https://api.github.com/repos/slackapi/slack-github-action/environments!
GET request failed due to transport error re-trying!
Making GET API request to https://api.github.com/repos/slackapi/slack-github-action/environments!
GET request failed due to transport error re-trying!
Making GET API request to https://api.github.com/repos/slackapi/slack-github-action/environments!
GET request failed due to transport error re-trying!
Error processing path: cannot access local variable 'api_response' where it is not associated with a value
```

After logs:

```
DEBUG:gatox.github.api:Making GET API request to https://api.github.com/repos/org/repo/environments!
WARNING:gatox.github.api:GET request https://api.github.com/repos/org/repo/environments failed due to transport error re-trying
Traceback (most recent call last):
  File "~/.venv/lib/python3.12/site-packages/gatox/github/api.py", line 329, in call_get
    api_response = await self.client.get(
                         ^^^^^^^^^^^^^^^
AttributeError: XXXX
DEBUG:gatox.github.api:Making GET API request to https://api.github.com/repos/org/repo/environments!
WARNING:gatox.github.api:GET request https://api.github.com/repos/org/repo/environments failed due to transport error re-trying
Traceback (most recent call last):
  File "~/.venv/lib/python3.12/site-packages/gatox/github/api.py", line 329, in call_get
    api_response = await self.client.get(
                         ^^^^^^^^^^^^^^^
AttributeError: XXXX
WARNING:gatox.workflow_graph.visitors.pwn_request_visitor:Error processing path: GET request https://api.github.com/repos/org/repo/environments failed after 5 attempts
```