### PR TITLE
Fix/false negative on permission check

### DIFF
--- a/unit_test/graph/test_pwn_req_visitor.py
+++ b/unit_test/graph/test_pwn_req_visitor.py
@@ -4,6 +4,9 @@ from gatox.workflow_graph.visitors.pwn_request_visitor import PwnRequestVisitor
 from gatox.workflow_graph.graph.tagged_graph import TaggedGraph
 from gatox.github.api import Api
 from gatox.workflow_graph.visitors.visitor_utils import VisitorUtils
+from gatox.enumerate.results.complexity import Complexity
+from gatox.enumerate.results.confidence import Confidence
+from gatox.enumerate.results.issue_type import IssueType
 
 
 @pytest.fixture
@@ -43,3 +46,243 @@ async def test_find_pwn_requests_with_nodes(mock_graph, mock_api, mock_cache_man
     ):
         await PwnRequestVisitor.find_pwn_requests(mock_graph, mock_api)
         mock_process.assert_called_once()
+
+
+async def test_process_single_path_with_memoization_logic(mock_graph, mock_api, mock_cache_manager):
+    """
+    Test that permission blockers and approval gates are memoized correctly,
+    and results are only suppressed when blocker nodes are actually in the final path.
+    """
+    # Create mock nodes for the path
+    workflow_node = MagicMock()
+    workflow_node.get_tags.return_value = ["WorkflowNode", "pull_request_target"]
+    workflow_node.excluded.return_value = False
+    workflow_node.get_env_vars.return_value = {}
+    workflow_node.repo_name.return_value = "test/repo"
+    
+    job_node = MagicMock()
+    job_node.get_tags.return_value = ["JobNode"]
+    job_node.deployments = None
+    job_node.outputs = None
+    job_node.repo_name.return_value = "test/repo"
+    
+    checkout_step = MagicMock()
+    checkout_step.get_tags.return_value = ["StepNode"]
+    checkout_step.is_checkout = True
+    checkout_step.metadata = "refs/heads/main"
+    checkout_step.outputs = None
+    checkout_step.hard_gate = False
+    checkout_step.soft_gate = False
+    
+    # Create mock blocker and approval gate nodes (not in main path)
+    blocker_node = MagicMock()
+    blocker_node.get_tags.return_value = ["permission_blocker"]
+    
+    approval_gate_node = MagicMock()
+    approval_gate_node.get_tags.return_value = ["permission_check"]
+    
+    # Create sink node
+    sink_node = MagicMock()
+    sink_node.get_tags.return_value = ["sink"]
+    
+    # Set up the path
+    path = [workflow_node, job_node, checkout_step]
+    
+    # Mock the graph DFS calls
+    def mock_dfs_side_effect(node, tag, api):
+        if tag == "permission_blocker":
+            # Return paths to blocker nodes that are NOT in the main path
+            return [[blocker_node]]
+        elif tag == "permission_check":
+            # Return paths to approval gate nodes that are NOT in the main path  
+            return [[approval_gate_node]]
+        elif tag == "sink":
+            # Return sink path
+            return [[sink_node]]
+        return []
+    
+    mock_graph.dfs_to_tag.side_effect = mock_dfs_side_effect
+    
+    # Mock API calls
+    mock_api.get_all_environment_protection_rules.return_value = {}
+    
+    results = {}
+    rule_cache = {}
+    
+    # Mock VisitorUtils methods
+    with (
+        patch.object(VisitorUtils, "process_context_var", return_value="processed"),
+        patch.object(VisitorUtils, "check_mutable_ref", return_value=True),
+        patch.object(VisitorUtils, "append_path"),
+        patch.object(VisitorUtils, "_add_results") as mock_add_results,
+    ):
+        
+        await PwnRequestVisitor._process_single_path(
+            path, mock_graph, mock_api, rule_cache, results
+        )
+        
+        # Verify that results were added (since blocker nodes are not in the main path)
+        mock_add_results.assert_called_once()
+        call_args = mock_add_results.call_args
+        
+        # Check that the path was passed correctly
+        assert call_args[0][0] == path
+        assert call_args[0][1] == results
+        assert call_args[0][2] == IssueType.PWN_REQUEST
+        
+        # Verify complexity and confidence
+        assert call_args[1]['complexity'] == Complexity.ZERO_CLICK  # No approval gate in path
+        assert call_args[1]['confidence'] == Confidence.HIGH  # Sink found
+
+
+async def test_process_single_path_blocker_in_path_suppresses_results(mock_graph, mock_api, mock_cache_manager):
+    """
+    Test that results are suppressed when a blocker node is actually in the final path.
+    """
+    # Create mock nodes
+    workflow_node = MagicMock()
+    workflow_node.get_tags.return_value = ["WorkflowNode", "pull_request_target"]
+    workflow_node.excluded.return_value = False
+    workflow_node.get_env_vars.return_value = {}
+    workflow_node.repo_name.return_value = "test/repo"
+    
+    job_node = MagicMock()
+    job_node.get_tags.return_value = ["JobNode"]
+    job_node.deployments = None
+    job_node.outputs = None
+    job_node.repo_name.return_value = "test/repo"
+    
+    # This blocker node is part of the main path
+    blocker_step = MagicMock()
+    blocker_step.get_tags.return_value = ["StepNode", "permission_blocker"]
+    blocker_step.is_checkout = False
+    blocker_step.outputs = None
+    blocker_step.hard_gate = False
+    blocker_step.soft_gate = False
+    
+    checkout_step = MagicMock()
+    checkout_step.get_tags.return_value = ["StepNode"]
+    checkout_step.is_checkout = True
+    checkout_step.metadata = "refs/heads/main"
+    checkout_step.outputs = None
+    checkout_step.hard_gate = False
+    checkout_step.soft_gate = False
+    
+    sink_node = MagicMock()
+    sink_node.get_tags.return_value = ["sink"]
+    
+    # Path includes the blocker node
+    path = [workflow_node, job_node, blocker_step, checkout_step]
+    
+    # Mock the graph DFS calls
+    def mock_dfs_side_effect(node, tag, api):
+        if tag == "permission_blocker":
+            # Return path that includes the blocker_step (which is in main path)
+            return [[blocker_step]]
+        elif tag == "permission_check":
+            return []
+        elif tag == "sink":
+            return [[sink_node]]
+        return []
+    
+    mock_graph.dfs_to_tag.side_effect = mock_dfs_side_effect
+    
+    # Mock API calls
+    mock_api.get_all_environment_protection_rules.return_value = {}
+    
+    results = {}
+    rule_cache = {}
+    
+    # Mock VisitorUtils methods
+    with (
+        patch.object(VisitorUtils, "process_context_var", return_value="processed"),
+        patch.object(VisitorUtils, "check_mutable_ref", return_value=True),
+        patch.object(VisitorUtils, "append_path"),
+        patch.object(VisitorUtils, "_add_results") as mock_add_results,
+    ):
+        
+        await PwnRequestVisitor._process_single_path(
+            path, mock_graph, mock_api, rule_cache, results
+        )
+        
+        # Verify that results were NOT added (blocker node is in the path)
+        mock_add_results.assert_not_called()
+
+
+async def test_process_single_path_approval_gate_affects_complexity(mock_graph, mock_api, mock_cache_manager):
+    """
+    Test that approval gate nodes in the path correctly affect complexity calculation.
+    """
+    # Create mock nodes
+    workflow_node = MagicMock()
+    workflow_node.get_tags.return_value = ["WorkflowNode", "pull_request_target"]
+    workflow_node.excluded.return_value = False
+    workflow_node.get_env_vars.return_value = {}
+    workflow_node.repo_name.return_value = "test/repo"
+    
+    job_node = MagicMock()
+    job_node.get_tags.return_value = ["JobNode"]
+    job_node.deployments = None
+    job_node.outputs = None
+    job_node.repo_name.return_value = "test/repo"
+    
+    # This approval gate node is part of the main path
+    approval_step = MagicMock()
+    approval_step.get_tags.return_value = ["StepNode", "permission_check"]
+    approval_step.is_checkout = False
+    approval_step.outputs = None
+    approval_step.hard_gate = False
+    approval_step.soft_gate = False
+    
+    checkout_step = MagicMock()
+    checkout_step.get_tags.return_value = ["StepNode"]
+    checkout_step.is_checkout = True
+    checkout_step.metadata = "refs/heads/main"
+    checkout_step.outputs = None
+    checkout_step.hard_gate = False
+    checkout_step.soft_gate = False
+    
+    sink_node = MagicMock()
+    sink_node.get_tags.return_value = ["sink"]
+    
+    # Path includes the approval gate node
+    path = [workflow_node, job_node, approval_step, checkout_step]
+    
+    # Mock the graph DFS calls
+    def mock_dfs_side_effect(node, tag, api):
+        if tag == "permission_blocker":
+            return []
+        elif tag == "permission_check":
+            # Return path that includes the approval_step (which is in main path)
+            return [[approval_step]]
+        elif tag == "sink":
+            return [[sink_node]]
+        return []
+    
+    mock_graph.dfs_to_tag.side_effect = mock_dfs_side_effect
+    
+    # Mock API calls
+    mock_api.get_all_environment_protection_rules.return_value = {}
+    
+    results = {}
+    rule_cache = {}
+    
+    # Mock VisitorUtils methods
+    with (
+        patch.object(VisitorUtils, "process_context_var", return_value="processed"),
+        patch.object(VisitorUtils, "check_mutable_ref", return_value=True),
+        patch.object(VisitorUtils, "append_path"),
+        patch.object(VisitorUtils, "_add_results") as mock_add_results,
+    ):
+        
+        await PwnRequestVisitor._process_single_path(
+            path, mock_graph, mock_api, rule_cache, results
+        )
+        
+        # Verify that results were added
+        mock_add_results.assert_called_once()
+        call_args = mock_add_results.call_args
+        
+        # Check that complexity is TOCTOU due to effective approval gate
+        assert call_args[1]['complexity'] == Complexity.TOCTOU
+        assert call_args[1]['confidence'] == Confidence.HIGH

--- a/unit_test/graph/test_pwn_req_visitor.py
+++ b/unit_test/graph/test_pwn_req_visitor.py
@@ -48,7 +48,9 @@ async def test_find_pwn_requests_with_nodes(mock_graph, mock_api, mock_cache_man
         mock_process.assert_called_once()
 
 
-async def test_process_single_path_with_memoization_logic(mock_graph, mock_api, mock_cache_manager):
+async def test_process_single_path_with_memoization_logic(
+    mock_graph, mock_api, mock_cache_manager
+):
     """
     Test that permission blockers and approval gates are memoized correctly,
     and results are only suppressed when blocker nodes are actually in the final path.
@@ -59,13 +61,13 @@ async def test_process_single_path_with_memoization_logic(mock_graph, mock_api, 
     workflow_node.excluded.return_value = False
     workflow_node.get_env_vars.return_value = {}
     workflow_node.repo_name.return_value = "test/repo"
-    
+
     job_node = MagicMock()
     job_node.get_tags.return_value = ["JobNode"]
     job_node.deployments = None
     job_node.outputs = None
     job_node.repo_name.return_value = "test/repo"
-    
+
     checkout_step = MagicMock()
     checkout_step.get_tags.return_value = ["StepNode"]
     checkout_step.is_checkout = True
@@ -73,42 +75,42 @@ async def test_process_single_path_with_memoization_logic(mock_graph, mock_api, 
     checkout_step.outputs = None
     checkout_step.hard_gate = False
     checkout_step.soft_gate = False
-    
+
     # Create mock blocker and approval gate nodes (not in main path)
     blocker_node = MagicMock()
     blocker_node.get_tags.return_value = ["permission_blocker"]
-    
+
     approval_gate_node = MagicMock()
     approval_gate_node.get_tags.return_value = ["permission_check"]
-    
+
     # Create sink node
     sink_node = MagicMock()
     sink_node.get_tags.return_value = ["sink"]
-    
+
     # Set up the path
     path = [workflow_node, job_node, checkout_step]
-    
+
     # Mock the graph DFS calls
     def mock_dfs_side_effect(node, tag, api):
         if tag == "permission_blocker":
             # Return paths to blocker nodes that are NOT in the main path
             return [[blocker_node]]
         elif tag == "permission_check":
-            # Return paths to approval gate nodes that are NOT in the main path  
+            # Return paths to approval gate nodes that are NOT in the main path
             return [[approval_gate_node]]
         elif tag == "sink":
             # Return sink path
             return [[sink_node]]
         return []
-    
+
     mock_graph.dfs_to_tag.side_effect = mock_dfs_side_effect
-    
+
     # Mock API calls
     mock_api.get_all_environment_protection_rules.return_value = {}
-    
+
     results = {}
     rule_cache = {}
-    
+
     # Mock VisitorUtils methods
     with (
         patch.object(VisitorUtils, "process_context_var", return_value="processed"),
@@ -116,26 +118,30 @@ async def test_process_single_path_with_memoization_logic(mock_graph, mock_api, 
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-        
+
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
-        
+
         # Verify that results were added (since blocker nodes are not in the main path)
         mock_add_results.assert_called_once()
         call_args = mock_add_results.call_args
-        
+
         # Check that the path was passed correctly
         assert call_args[0][0] == path
         assert call_args[0][1] == results
         assert call_args[0][2] == IssueType.PWN_REQUEST
-        
+
         # Verify complexity and confidence
-        assert call_args[1]['complexity'] == Complexity.ZERO_CLICK  # No approval gate in path
-        assert call_args[1]['confidence'] == Confidence.HIGH  # Sink found
+        assert (
+            call_args[1]["complexity"] == Complexity.ZERO_CLICK
+        )  # No approval gate in path
+        assert call_args[1]["confidence"] == Confidence.HIGH  # Sink found
 
 
-async def test_process_single_path_blocker_in_path_suppresses_results(mock_graph, mock_api, mock_cache_manager):
+async def test_process_single_path_blocker_in_path_suppresses_results(
+    mock_graph, mock_api, mock_cache_manager
+):
     """
     Test that results are suppressed when a blocker node is actually in the final path.
     """
@@ -145,13 +151,13 @@ async def test_process_single_path_blocker_in_path_suppresses_results(mock_graph
     workflow_node.excluded.return_value = False
     workflow_node.get_env_vars.return_value = {}
     workflow_node.repo_name.return_value = "test/repo"
-    
+
     job_node = MagicMock()
     job_node.get_tags.return_value = ["JobNode"]
     job_node.deployments = None
     job_node.outputs = None
     job_node.repo_name.return_value = "test/repo"
-    
+
     # This blocker node is part of the main path
     blocker_step = MagicMock()
     blocker_step.get_tags.return_value = ["StepNode", "permission_blocker"]
@@ -159,7 +165,7 @@ async def test_process_single_path_blocker_in_path_suppresses_results(mock_graph
     blocker_step.outputs = None
     blocker_step.hard_gate = False
     blocker_step.soft_gate = False
-    
+
     checkout_step = MagicMock()
     checkout_step.get_tags.return_value = ["StepNode"]
     checkout_step.is_checkout = True
@@ -167,13 +173,13 @@ async def test_process_single_path_blocker_in_path_suppresses_results(mock_graph
     checkout_step.outputs = None
     checkout_step.hard_gate = False
     checkout_step.soft_gate = False
-    
+
     sink_node = MagicMock()
     sink_node.get_tags.return_value = ["sink"]
-    
+
     # Path includes the blocker node
     path = [workflow_node, job_node, blocker_step, checkout_step]
-    
+
     # Mock the graph DFS calls
     def mock_dfs_side_effect(node, tag, api):
         if tag == "permission_blocker":
@@ -184,15 +190,15 @@ async def test_process_single_path_blocker_in_path_suppresses_results(mock_graph
         elif tag == "sink":
             return [[sink_node]]
         return []
-    
+
     mock_graph.dfs_to_tag.side_effect = mock_dfs_side_effect
-    
+
     # Mock API calls
     mock_api.get_all_environment_protection_rules.return_value = {}
-    
+
     results = {}
     rule_cache = {}
-    
+
     # Mock VisitorUtils methods
     with (
         patch.object(VisitorUtils, "process_context_var", return_value="processed"),
@@ -200,16 +206,18 @@ async def test_process_single_path_blocker_in_path_suppresses_results(mock_graph
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-        
+
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
-        
+
         # Verify that results were NOT added (blocker node is in the path)
         mock_add_results.assert_not_called()
 
 
-async def test_process_single_path_approval_gate_affects_complexity(mock_graph, mock_api, mock_cache_manager):
+async def test_process_single_path_approval_gate_affects_complexity(
+    mock_graph, mock_api, mock_cache_manager
+):
     """
     Test that approval gate nodes in the path correctly affect complexity calculation.
     """
@@ -219,13 +227,13 @@ async def test_process_single_path_approval_gate_affects_complexity(mock_graph, 
     workflow_node.excluded.return_value = False
     workflow_node.get_env_vars.return_value = {}
     workflow_node.repo_name.return_value = "test/repo"
-    
+
     job_node = MagicMock()
     job_node.get_tags.return_value = ["JobNode"]
     job_node.deployments = None
     job_node.outputs = None
     job_node.repo_name.return_value = "test/repo"
-    
+
     # This approval gate node is part of the main path
     approval_step = MagicMock()
     approval_step.get_tags.return_value = ["StepNode", "permission_check"]
@@ -233,7 +241,7 @@ async def test_process_single_path_approval_gate_affects_complexity(mock_graph, 
     approval_step.outputs = None
     approval_step.hard_gate = False
     approval_step.soft_gate = False
-    
+
     checkout_step = MagicMock()
     checkout_step.get_tags.return_value = ["StepNode"]
     checkout_step.is_checkout = True
@@ -241,13 +249,13 @@ async def test_process_single_path_approval_gate_affects_complexity(mock_graph, 
     checkout_step.outputs = None
     checkout_step.hard_gate = False
     checkout_step.soft_gate = False
-    
+
     sink_node = MagicMock()
     sink_node.get_tags.return_value = ["sink"]
-    
+
     # Path includes the approval gate node
     path = [workflow_node, job_node, approval_step, checkout_step]
-    
+
     # Mock the graph DFS calls
     def mock_dfs_side_effect(node, tag, api):
         if tag == "permission_blocker":
@@ -258,15 +266,15 @@ async def test_process_single_path_approval_gate_affects_complexity(mock_graph, 
         elif tag == "sink":
             return [[sink_node]]
         return []
-    
+
     mock_graph.dfs_to_tag.side_effect = mock_dfs_side_effect
-    
+
     # Mock API calls
     mock_api.get_all_environment_protection_rules.return_value = {}
-    
+
     results = {}
     rule_cache = {}
-    
+
     # Mock VisitorUtils methods
     with (
         patch.object(VisitorUtils, "process_context_var", return_value="processed"),
@@ -274,15 +282,15 @@ async def test_process_single_path_approval_gate_affects_complexity(mock_graph, 
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-        
+
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
-        
+
         # Verify that results were added
         mock_add_results.assert_called_once()
         call_args = mock_add_results.call_args
-        
+
         # Check that complexity is TOCTOU due to effective approval gate
-        assert call_args[1]['complexity'] == Complexity.TOCTOU
-        assert call_args[1]['confidence'] == Confidence.HIGH
+        assert call_args[1]["complexity"] == Complexity.TOCTOU
+        assert call_args[1]["confidence"] == Confidence.HIGH


### PR DESCRIPTION
## Pull Request Overview

The Pwn Request visitor had a bug where it would fail to report a Pwn Request if a permission check or blocker was reachable _after_ a sink. This would lead to a false negative.

## What does this PR add/solve?

Solves the false negative by memoizing the permission blocker node. Once Gato-X is about to report a result, it will check if the blocker node exists in the path. If it does, then Gato-X suppresses the result.

This isn't a perfect fix because the ideal solution will be to encode the reachability in the graph itself, so the dfs to find a blocker only checks the graph "backwards". Will tackle the proper fix later as it risks breaking other detections.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security enhancement
- [ ] CI/CD improvement

### Areas affected
- [x] Enumeration functionality
- [ ] Attack/Exploitation features
- [ ] GitHub API integration
- [x] Workflow analysis
- [ ] Runner detection
- [ ] MCP Server
- [ ] CLI/User interface
- [ ] Documentation
- [x] Tests
- [ ] Configuration

## Testing Steps

Added unit tests.

### Manual Testing
1. Tested on false positive case and validated issue does not trigger.

### Automated Testing
- [x] All existing unit tests pass
- [x] New unit tests added for new functionality
- [ ] Integration tests updated/added if applicable
- [x] Code coverage maintained or improved

### Testing Commands
```bash
# Add specific commands to test this PR
# Example:
# python -m pytest unit_test/test_new_feature.py
# python -m gatox enumerate --help
```

## Security Considerations

<!-- If this PR affects security-related functionality, describe any security implications -->

- [ ] This change does not introduce new security risks
- [ ] This change has been reviewed for potential security vulnerabilities
- [ ] This change improves existing security measures
- [x] N/A - No security implications

## Documentation

<!-- Check all that apply -->

- [ ] Code changes are documented with appropriate comments
- [ ] Public API changes are documented
- [ ] README.md updated if needed
- [ ] Documentation site updated if needed (docs/ folder)
- [ ] CHANGELOG.md updated if applicable

## Checklist

<!-- Please check all applicable items -->

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published


