### PR TITLE
Fix TOCTOU False Positive

### DIFF
--- a/gatox/workflow_graph/visitors/visitor_utils.py
+++ b/gatox/workflow_graph/visitors/visitor_utils.py
@@ -116,6 +116,16 @@ class VisitorUtils:
 
         return ancestors
 
+    # Class-level constants for immutable reference patterns
+    _IMMUTABLE_PATTERNS = frozenset(
+        [
+            "github.event.pull_request.head.sha",
+            "github.event.pull_request.merge_commit_sha",
+            "github.event.workflow_run.head.sha",
+            "github.sha",
+        ]
+    )
+
     @staticmethod
     def check_mutable_ref(ref, start_tags=None):
         """
@@ -133,20 +143,18 @@ class VisitorUtils:
         """
         if start_tags is None:
             start_tags = set()
-        if "github.event.pull_request.head.sha" in ref:
+
+        # Check immutable patterns using any() for early termination
+        if any(pattern in ref for pattern in VisitorUtils._IMMUTABLE_PATTERNS):
             return False
-        elif "github.event.pull_request.merge_commit_sha" in ref:
-            return False
-        elif "github.event.workflow_run.head.sha" in ref:
-            return False
-        elif "github.sha" in ref:
-            return False
+
         # If the trigger is pull_request_target and we have a sha in the reference, then this is very likely
         # to be from the original trigger in some form and not a mutable reference, so if it is gated we can suppress.
-        elif "sha" in ref and "pull_request_target" in start_tags:
+        if "sha" in ref and "pull_request_target" in start_tags:
             return False
+
         # This points to the base branch, so it is not going to be exploitable.
-        elif "github.ref" in ref and "||" not in ref:
+        if "github.ref" in ref and "||" not in ref:
             return False
 
         return True

--- a/gatox/workflow_graph/visitors/visitor_utils.py
+++ b/gatox/workflow_graph/visitors/visitor_utils.py
@@ -135,6 +135,8 @@ class VisitorUtils:
             start_tags = set()
         if "github.event.pull_request.head.sha" in ref:
             return False
+        elif "github.event.pull_request.merge_commit_sha" in ref:
+            return False
         elif "github.event.workflow_run.head.sha" in ref:
             return False
         elif "github.sha" in ref:

--- a/unit_test/graph/test_visitor_utils.py
+++ b/unit_test/graph/test_visitor_utils.py
@@ -91,6 +91,9 @@ def test_add_results():
 def test_check_mutable_ref():
     # Test immutable refs
     assert not VisitorUtils.check_mutable_ref("github.event.pull_request.head.sha")
+    assert not VisitorUtils.check_mutable_ref(
+        "github.event.pull_request.merge_commit_sha"
+    )
     assert not VisitorUtils.check_mutable_ref("github.event.workflow_run.head.sha")
     assert not VisitorUtils.check_mutable_ref("github.sha")
     assert not VisitorUtils.check_mutable_ref("sha", {"pull_request_target"})


### PR DESCRIPTION
…label

## Pull Request Overview

<!-- Provide a brief summary of the changes in this PR -->

## What does this PR add/solve

Fixes a false positive for PRT label TOCTOU.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security enhancement
- [ ] CI/CD improvement

### Areas affected
- [x] Enumeration functionality
- [ ] Attack/Exploitation features
- [ ] GitHub API integration
- [ ] Workflow analysis
- [ ] Runner detection
- [ ] MCP Server
- [ ] CLI/User interface
- [ ] Documentation
- [ ] Tests
- [ ] Configuration

## Testing Steps

<!-- Describe how you tested these changes. Include specific steps for reviewers to verify the functionality -->

### Manual Testing

Tested against https://github.com/valkey-io/valkey/blob/unstable/.github/workflows/benchmark-on-label.yml, which was throwing a false positive.

```yaml
name: On-demand Benchmark

on:
  pull_request_target:
    types: [labeled]

concurrency:
  group: valkey-pr-benchmark
  cancel-in-progress: false

defaults:
  run:
    shell: "bash -Eeuo pipefail -x {0}"

permissions:
  contents: read
  pull-requests: write
  issues: write

jobs:
  benchmark:
    runs-on: ${{ github.repository == 'valkey-io/valkey' && fromJSON('["self-hosted","ec2-ubuntu-24.04-benchmarking"]') || 'ubuntu-latest' }}
    if: |
      github.event.action == 'labeled' && github.event.label.name == 'run-benchmark'
    steps:
      - name: Checkout valkey
        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
        with:
          path: valkey
          fetch-depth: 0
          ref: ${{ github.event.pull_request.merge_commit_sha }}
          persist-credentials: false
```

### Automated Testing
- [x] All existing unit tests pass
- [x] New unit tests added for new functionality
- [x] Integration tests updated/added if applicable
- [x] Code coverage maintained or improved

### Testing Commands
```bash
# Add specific commands to test this PR
# Example:
# python -m pytest unit_test/test_new_feature.py
# python -m gatox enumerate --help
```

## Security Considerations

<!-- If this PR affects security-related functionality, describe any security implications -->

- [ ] This change does not introduce new security risks
- [ ] This change has been reviewed for potential security vulnerabilities
- [ ] This change improves existing security measures
- [ ] N/A - No security implications

## Documentation

<!-- Check all that apply -->

- [ ] Code changes are documented with appropriate comments
- [ ] Public API changes are documented
- [ ] README.md updated if needed
- [ ] Documentation site updated if needed (docs/ folder)
- [ ] CHANGELOG.md updated if applicable

## Checklist

<!-- Please check all applicable items -->

- [ ] My code follows the project's coding style and conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information that might be helpful for reviewers -->

### Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

### Performance Impact
<!-- Describe any performance implications of this change -->

### Breaking Changes
<!-- If this is a breaking change, describe what users need to do to adapt -->

### Related Issues/PRs
<!-- Link to related issues or PRs -->

Closes #
Related to #
