### PR TITLE
feature: Add enumeration capabilities for Fine-Grained GitHub Personal Access Tokens

### DIFF
--- a/docs/user-guide/advanced/fine-grained-tokens.md
+++ b/docs/user-guide/advanced/fine-grained-tokens.md
@@ -1,0 +1,170 @@
+# GitHub Fine-Grained Personal Access Tokens
+
+GitHub Fine-Grained Personal Access Tokens (PATs) represent a more secure and granular approach to GitHub API authentication compared to classic PATs. This document covers what fine-grained tokens are, how they work, and how Gato-X leverages them for security enumeration.
+
+## What are Fine-Grained PATs?
+
+Fine-grained PATs were introduced by GitHub to provide more precise permission control over API access. Unlike classic PATs that use broad scopes (like `repo`, `admin:org`), fine-grained tokens allow you to specify exact permissions for specific repositories or organizations.
+
+### Key Differences from Classic PATs
+
+| Feature | Classic PATs | Fine-Grained PATs |
+|---------|-------------|-------------------|
+| **Scope Granularity** | Broad scopes (e.g., `repo` gives access to all repos) | Specific permissions per repository/organization |
+| **Resource Selection** | All accessible resources | Explicitly selected repositories/organizations |
+| **Permission Types** | Fixed scope combinations | Granular permission matrix (read/write per resource type) |
+| **Token Format** | `ghp_` prefix | `github_pat_` prefix |
+| **Expiration** | Optional (can be permanent) | Maximum 1 year, recommended shorter periods |
+
+### Fine-Grained Permission Model
+
+Fine-grained tokens use a permission model based on:
+
+- **Resource Types**: Contents, Issues, Pull Requests, Actions, Secrets, etc.
+- **Permission Levels**: None, Read, Write (where applicable)
+- **Scope**: Repository-specific or organization-specific
+
+Common fine-grained permissions include:
+- `contents:read` / `contents:write` - Repository contents and commits
+- `issues:read` / `issues:write` - Issues and issue comments
+- `pull_requests:read` / `pull_requests:write` - Pull requests and reviews
+- `actions:read` / `actions:write` - GitHub Actions workflows and runs
+- `secrets:read` - Repository and organization secrets (read-only)
+- `administration:read` - Repository administration settings
+- `variables:read` / `variables:write` - Repository and organization variables
+
+## How Gato-X Handles Fine-Grained Tokens
+
+Gato-X automatically detects fine-grained tokens by their `github_pat_` prefix and uses specialized enumeration techniques optimized for the fine-grained permission model.
+
+### Token Detection
+
+```python
+if "github_pat" in args.gh_token:
+    await enumerate_finegrained(args, parser)
+else:
+    await enumerate_classic(args, parser)
+```
+
+### Fine-Grained Enumeration Process
+
+1. **Token Validation**: Verify the token is valid and get user information
+2. **Repository Discovery**: Find accessible repositories (public and private)
+3. **Write Access Detection**: Check for write permissions on public repositories via collaborators endpoint
+4. **Permission Probing**: Systematically test various endpoints to detect available permissions
+5. **Workflow Analysis**: Enumerate accessible repositories for GitHub Actions workflows and secrets
+
+### Permission Probing Strategy
+
+Gato-X uses a multi-stage approach to detect fine-grained permissions:
+
+#### Stage 1: Read Permission Detection
+Gato-X probes various GET endpoints to detect read permissions:
+
+```python
+private_probe_map = {
+    "contents:read": f"/repos/{repo}/commits",
+    "issues:read": f"/repos/{repo}/issues", 
+    "pull_requests:read": f"/repos/{repo}/pulls",
+    "actions:read": f"/repos/{repo}/actions/workflows",
+    "secrets:read": f"/repos/{repo}/actions/secrets",
+    "administration:read": f"/repos/{repo}/actions/permissions",
+    "variables:read": f"/repos/{repo}/actions/variables",
+    "deployments:read": f"/repos/{repo}/deployments",
+    "webhooks:read": f"/repos/{repo}/hooks"
+}
+```
+
+#### Stage 2: Write Permission Detection
+For each detected read permission, Gato-X attempts to detect corresponding write permissions:
+
+- **Contents Write**: Create a blob via `/repos/{repo}/git/blobs`
+- **Issues Write**: Attempt to PATCH an existing issue with no changes
+- **Pull Requests Write**: Attempt to PATCH an existing PR with no changes  
+- **Actions Write**: Get and re-set OIDC customization settings
+
+Each probe is effectively a no-op. The issues, PR and actions probe do not change anything, and the events do not trigger audit logs events (as of writing).
+
+The contents write probe creates a small dangling blob in the Git database.
+
+#### Public Repository Handling
+
+For public repositories, Gato-X performs write permission probes for scopes such as issues, pull_request, and actions because most public repo read endpoints always succeed regardless of the token's scopes.
+
+
+## Security Implications
+
+### From a Defender's Perspective
+
+Fine-grained tokens provide several security benefits:
+
+1. **Principle of Least Privilege**: Tokens can be scoped to exactly the permissions needed
+2. **Reduced Blast Radius**: Compromised tokens have limited access scope
+3. **Better Auditability**: Clearer permission boundaries make access reviews easier
+4. **Forced Expiration**: Maximum 1-year expiration reduces long-term exposure risk
+
+### From an Attacker's Perspective  
+
+Fine-grained tokens present both challenges and opportunities:
+
+**Challenges:**
+- More restrictive permissions may limit attack surface
+- Shorter expiration times reduce persistence
+- Resource-specific access may prevent lateral movement
+
+**Opportunities:**
+- Organizations may over-grant permissions during initial setup
+- Write permissions to specific repos can still be highly valuable
+- Actions and secrets access remains critical for supply chain attacks
+
+## Common Escalation Scenarios
+
+### Scenario 1: Development Token
+A developer creates a fine-grained token for their CI/CD pipeline:
+- **Permissions**: `contents:write`, `actions:write` on specific repositories
+- **Gato-X Detection**: Will identify write access to repository contents and Actions workflows
+- **Security Risk**: Potential for code injection by altering scripts on non-default branches and triggering `workflow_dispatch` events.
+
+### Scenario 2: Bot Account Token
+An automation bot has read access across multiple repositories:
+- **Permissions**: `contents:read`, `issues:read`, `pull_requests:read` on organization repos
+- **Gato-X Detection**: Will enumerate all accessible repositories and their contents
+
+## Best Practices for Defense
+
+1. **Regular Token Audits**: Review active fine-grained tokens and their permissions
+2. **Minimal Permissions**: Grant only the minimum permissions required
+3. **Short Expiration**: Use the shortest practical expiration periods
+4. **Repository Scoping**: Limit tokens to specific repositories when possible
+5. **Monitoring**: Implement logging and alerting for token usage patterns
+6. **Rotation**: Establish regular token rotation procedures
+
+## Understanding Gato-X Output
+
+When Gato-X enumerates a fine-grained token, the output includes:
+
+- **User Information**: Token owner and expiration details
+- **Repository Access**: List of accessible repositories (public/private)
+- **Detected Permissions**: Specific fine-grained permissions identified
+- **Write Access Summary**: Repositories with write+ access
+- **Workflow Details**: GitHub Actions workflows and potential attack vectors
+
+Example output:
+```
+[INFO] Starting fine-grained token enumeration
+[INFO] The authenticated user is: example-user
+[INFO] Token expiration: 2024-12-31T23:59:59Z
+[INFO] Token has access to 5 private repo(s)
+[INFO] Probing endpoints to detect scopes...
+ contents:read ✅
+ issues:write ✅
+ pull_requests:read ✅
+ actions:write ✅
+ secrets:read ✅
+```
+
+## Conclusion
+
+Fine-grained PATs represent a significant improvement in GitHub's security model, but they also require updated approaches for both security testing. Gato-X's specialized fine-grained enumeration capabilities help security teams understand the true scope and risk of these tokens in their environment.
+
+By understanding how fine-grained tokens work and how Gato-X enumerates them, security professionals can better assess their GitHub security posture and implement appropriate controls.

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -21,6 +21,7 @@ from gatox.cli.persistence.config import configure_parser_persistence
 from gatox.cli.search.config import configure_parser_search
 from gatox.enumerate.app_enumerate import AppEnumerator
 from gatox.enumerate.enumerate import Enumerator
+from gatox.enumerate.finegrained_enumeration import FineGrainedEnumerator
 from gatox.models.execution import Execution
 from gatox.search.search import Searcher
 from gatox.util.arg_utils import read_file_and_validate_lines
@@ -136,12 +137,9 @@ def validate_arguments(args, parser):
         else:
             gh_token = os.environ["GH_TOKEN"]
 
-        if "github_pat_" in gh_token:
-            parser.error(
-                f"{Fore.RED}[!] Fine-grained PATs are currently not supported!"
-            )
-
-        if not (
+        if re.match(r"github_pat_[A-Za-z0-9_]{22}_[A-Za-z0-9_]{59}$", gh_token):
+            logging.info("Using fine-grained token.")
+        elif not (
             re.match("gh[po]_[A-Za-z0-9]{36}$", gh_token)
             or re.match("^[a-fA-F0-9]{40}$", gh_token)
         ):
@@ -309,38 +307,51 @@ async def attack(args, parser):
         )
 
 
-async def enumerate(args, parser):
-    parser = parser.choices["enumerate"]
-
-    if not (
-        args.target
-        or args.self_enumeration
-        or args.repository
-        or args.repositories
-        or args.validate
-        or args.commit
-    ):
-        parser.error(
-            f"{Fore.RED}[-]{Style.RESET_ALL} No enumeration type was specified!"
-        )
-
-    # Count enumeration types, treating commit as a modifier for repository
-    enumeration_count = sum(
-        bool(x)
-        for x in [
-            args.target,
-            args.self_enumeration,
-            args.repository or args.commit,  # repository and commit work together
-            args.repositories,
-            args.validate,
-        ]
+async def enumerate_finegrained(args, parser):
+    """Execute fine-grained token enumeration workflow."""
+    gh_enumeration_runner = FineGrainedEnumerator(
+        pat=args.gh_token,
+        socks_proxy=args.socks_proxy,
+        http_proxy=args.http_proxy,
+        skip_log=args.skip_runners,
+        github_url=args.api_url,
+        ignore_workflow_run=args.ignore_workflow_run,
+        deep_dive=args.deep_dive,
     )
 
-    if enumeration_count != 1:
+    if args.validate:
+        # For validation, just check token validity
+        await gh_enumeration_runner.validate_token_and_get_user()
+        exec_wrapper = Execution()
+        exec_wrapper.set_user_details(gh_enumeration_runner.user_perms)
+    elif args.self_enumeration:
+        # Fine-grained self enumeration
+        accessible_repos, results = (
+            await gh_enumeration_runner.enumerate_fine_grained_token(enum_mode="self")
+        )
+        exec_wrapper = Execution()
+        exec_wrapper.set_user_details(gh_enumeration_runner.user_perms)
+        exec_wrapper.add_repositories(accessible_repos)
+    else:
+        # Fine-grained tokens only support self enum and single repo
         parser.error(
-            f"{Fore.RED}[-]{Style.RESET_ALL} You must only select one enumeration type."
+            f"{Fore.RED}[-]{Style.RESET_ALL} Fine-grained tokens only support "
+            "--self-enumeration or -validate modes!"
+        )
+        return
+
+    # Handle output
+    try:
+        if args.output_json:
+            Output.write_json(exec_wrapper, args.output_json)
+    except Exception:
+        Output.error(
+            "Encountered an error writing the output JSON, this is likely a Gato-X bug."
         )
 
+
+async def enumerate_classic(args, parser):
+    """Execute classic enumeration workflow."""
     gh_enumeration_runner = Enumerator(
         args.gh_token,
         socks_proxy=args.socks_proxy,
@@ -354,10 +365,6 @@ async def enumerate(args, parser):
     exec_wrapper = Execution()
     orgs = []
     repos = []
-
-    if args.cache_restore_file:
-        LocalCacheFactory.load_cache_from_file(args.cache_restore_file)
-        Output.info(f"Cache restored from file:{args.cache_restore_file}")
 
     if args.validate:
         orgs = await gh_enumeration_runner.validate_only()
@@ -409,6 +416,48 @@ async def enumerate(args, parser):
     if args.cache_save_file:
         LocalCacheFactory.dump_cache(args.cache_save_file)
         Output.info(f"Cache saved to file:{args.cache_save_file}")
+
+
+async def enumerate(args, parser):
+    parser = parser.choices["enumerate"]
+
+    if not (
+        args.target
+        or args.self_enumeration
+        or args.repository
+        or args.repositories
+        or args.validate
+        or args.commit
+    ):
+        parser.error(
+            f"{Fore.RED}[-]{Style.RESET_ALL} No enumeration type was specified!"
+        )
+
+    # Count enumeration types, treating commit as a modifier for repository
+    enumeration_count = sum(
+        bool(x)
+        for x in [
+            args.target,
+            args.self_enumeration,
+            args.repository or args.commit,  # repository and commit work together
+            args.repositories,
+            args.validate,
+        ]
+    )
+
+    if enumeration_count != 1:
+        parser.error(
+            f"{Fore.RED}[-]{Style.RESET_ALL} You must only select one enumeration type."
+        )
+
+    if args.cache_restore_file:
+        LocalCacheFactory.load_cache_from_file(args.cache_restore_file)
+        Output.info(f"Cache restored from file:{args.cache_restore_file}")
+
+    if "github_pat" in args.gh_token:
+        await enumerate_finegrained(args, parser)
+    else:
+        await enumerate_classic(args, parser)
 
 
 async def search(args, parser):

--- a/gatox/enumerate/finegrained_enumeration.py
+++ b/gatox/enumerate/finegrained_enumeration.py
@@ -1,0 +1,379 @@
+import logging
+from typing import Any
+
+from gatox.cli.output import Output
+from gatox.enumerate.enumerate import Enumerator
+from gatox.github.api import Api
+from gatox.models.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+
+class FineGrainedEnumerator(Enumerator):
+    """Class for enumerating fine-grained GitHub personal access tokens."""
+
+    def __init__(
+        self,
+        pat: str = None,
+        socks_proxy: str = None,
+        http_proxy: str = None,
+        skip_log: bool = False,
+        github_url: str = None,
+        output_json: str = None,
+        ignore_workflow_run: bool = False,
+        deep_dive: bool = False,
+        app_permisions: list = None,
+        api_client: Api = None,
+    ):
+        """Initialize the fine-grained enumerator.
+
+        Inherits all functionality from the base Enumerator class and adds
+        fine-grained token specific enumeration capabilities.
+
+        Args:
+            pat (str): GitHub personal access token
+            socks_proxy (str, optional): Proxy settings for SOCKS proxy.
+            http_proxy (str, optional): Proxy settings for HTTP proxy.
+            skip_log (bool, optional): If set, then run logs will not be downloaded.
+            github_url (str, optional): GitHub API URL.
+            output_json (str, optional): JSON file to output enumeration results.
+            ignore_workflow_run (bool, optional): If set, then "workflow_run" triggers will be ignored.
+            deep_dive (bool, optional): If set, then deep dive workflow ingestion will be performed.
+            app_permissions (list, optional): List of permissions for GitHub App.
+            api_client (Api, optional): An existing Api client instance.
+        """
+        # Initialize the parent Enumerator class
+        super().__init__(
+            pat=pat,
+            socks_proxy=socks_proxy,
+            http_proxy=http_proxy,
+            skip_log=skip_log,
+            github_url=github_url,
+            output_json=output_json,
+            ignore_workflow_run=ignore_workflow_run,
+            deep_dive=deep_dive,
+            app_permisions=app_permisions,
+            api_client=api_client,
+        )
+
+        # Fine-grained enumeration specific attributes
+        self.accessible_repos = []
+
+    async def __setup_user_info(self):
+        """Sets up user/app token information."""
+        if not self.user_perms:
+            self.user_perms = await self.api.check_user()
+            if not self.user_perms:
+                Output.error("This token cannot be used for enumeration!")
+                return False
+
+            Output.info(
+                f"The authenticated user is: {Output.bright(self.user_perms['user'])}"
+            )
+
+            if self.user_perms.get("expiration"):
+                Output.info(
+                    f"Token expiration: {Output.bright(self.user_perms['expiration'])}"
+                )
+
+        return True
+
+    async def validate_token_and_get_user(self) -> bool:
+        """Validates the token and gets the authenticated user.
+
+        Uses the parent class's user setup functionality.
+
+        Returns:
+            bool: True if token is valid and user info retrieved, False otherwise.
+        """
+        # Use the parent class's setup method
+        return await self.__setup_user_info()
+
+    async def check_collaborator_access(self, repo: dict[str, Any]) -> bool:
+        """Checks if the user has write+ access to a repository via collaborators endpoint.
+
+        This endpoint only works if the user has write+ access to the repository.
+        For fine-grained tokens, this indicates either:
+        1. The token has access to all repos, OR
+        2. The user explicitly opted this repo into the token's access
+
+        Args:
+            repo (Dict[str, Any]): Repository data from GitHub API.
+
+        Returns:
+            bool: True if user has write+ access, False otherwise.
+        """
+        try:
+            result = await self.api.call_get(f"/repos/{repo}/collaborators")
+
+            if result.status_code == 200:
+                Output.tabbed(f"Write+ access to {Output.bright(f'{repo}')}")
+                return True
+            elif result.status_code == 403:
+                # Expected for repos without write+ access
+                return False
+            else:
+                Output.warn(f"Unexpected status {result.status_code} for {repo}")
+                return False
+
+        except Exception as e:
+            logger.debug(
+                f"Error checking collaborator access for {repo.get('full_name', 'unknown')}: {e}"
+            )
+            return False
+
+    async def probe_write_access(
+        self, repo_to_check: str, valid_scopes: set[str], is_public: bool = False
+    ) -> None:
+        """Probes write access to a repository by attempting to create a blob.
+
+        Args:
+            repo_to_check (str): Repository to probe for write access.
+            valid_scopes (set[str]): Set of valid scopes to update if write access is found.
+            is_public (bool): Whether the repository is public (allows probing without read permission).
+        """
+        if "contents:read" in valid_scopes or is_public:
+            result = await self.api.call_post(
+                f"/repos/{repo_to_check}/git/blobs",
+                params={"content": "Write probe.", "encoding": "utf-8"},
+            )
+            if result.status_code == 201:
+                valid_scopes.remove("contents:read")
+                valid_scopes.add("contents:write")
+
+    async def probe_pull_requests_write_access(
+        self, repo_to_check: str, valid_scopes: set[str], is_public: bool = False
+    ) -> None:
+        """Probes pull requests write access by attempting to update a PR with no changes.
+
+        Args:
+            repo_to_check (str): Repository to probe for pull requests write access.
+            valid_scopes (set[str]): Set of valid scopes to update if write access is found.
+            is_public (bool): Whether the repository is public (allows probing without read permission).
+        """
+        if "pull_requests:read" in valid_scopes or is_public:
+            try:
+                # List pull requests
+                prs_result = await self.api.call_get(f"/repos/{repo_to_check}/pulls")
+
+                if prs_result.status_code == 200:
+                    prs = prs_result.json()
+
+                    # Find any open PR to test with
+                    if prs:
+                        pr_number = prs[0].get("number")
+
+                        # Issue a PATCH request with no params to test write access
+                        patch_result = await self.api.call_patch(
+                            f"/repos/{repo_to_check}/pulls/{pr_number}", params={}
+                        )
+
+                        # 403 means not valid, other status codes indicate valid write access
+                        if patch_result.status_code != 403:
+                            valid_scopes.remove("pull_requests:read")
+                            valid_scopes.add("pull_requests:write")
+
+            except Exception as e:
+                Output.tabbed(f" pull_requests:write: Error - {str(e)}")
+
+    async def probe_actions_write_access(
+        self, repo_to_check: str, valid_scopes: set[str], is_public: bool = False
+    ) -> None:
+        """Probes actions write access to a repository by attempting to get and then
+        re-set the OIDC customization settings.
+
+        Args:
+            repo_to_check (str): Repository to probe for actions write access.
+            valid_scopes (set[str]): Set of valid scopes to update if actions write access is found.
+            is_public (bool): Whether the repository is public (allows probing without read permission).
+        """
+        if "actions:read" in valid_scopes or is_public:
+            try:
+                # Get current OIDC customization settings
+                oidc_result = await self.api.call_get(
+                    f"/repos/{repo_to_check}/actions/oidc/customization/sub"
+                )
+
+                if oidc_result.status_code == 200:
+                    current_settings = oidc_result.json()
+
+                    # Try to set the same settings back (should return 201/204 if we have write access)
+                    set_result = await self.api.call_put(
+                        f"/repos/{repo_to_check}/actions/oidc/customization/sub",
+                        params=current_settings,
+                    )
+
+                    if set_result.status_code in [201, 204]:
+                        valid_scopes.add("actions:write")
+                        valid_scopes.remove("actions:read")
+
+            except Exception as e:
+                Output.tabbed(f" actions:write: Error - {str(e)}")
+
+    async def probe_issue_write_access(
+        self, repo_to_check: str, valid_scopes: set[str], is_public: bool = False
+    ) -> None:
+        """Probes issues write access by attempting to update an issue with no changes.
+
+        Args:
+            repo_to_check (str): Repository to probe for issues write access.
+            valid_scopes (set[str]): Set of valid scopes to update if write access is found.
+            is_public (bool): Whether the repository is public (allows probing without read permission).
+        """
+        if "issues:read" in valid_scopes or is_public:
+            try:
+                # List issues
+                issues_result = await self.api.call_get(
+                    f"/repos/{repo_to_check}/issues"
+                )
+
+                if issues_result.status_code == 200:
+                    issues = issues_result.json()
+
+                    # Find any issue to test with
+                    if issues:
+                        issue_number = issues[0].get("number")
+
+                        # Issue a PATCH request with no params to test write access
+                        patch_result = await self.api.call_patch(
+                            f"/repos/{repo_to_check}/issues/{issue_number}", params={}
+                        )
+
+                        # 403 means not valid, other status codes indicate valid write access
+                        if patch_result.status_code != 403:
+                            valid_scopes.remove("issues:read")
+                            valid_scopes.add("issues:write")
+
+            except Exception as e:
+                Output.tabbed(f" issues:write: Error - {str(e)}")
+
+    async def detect_scopes(self, repo_to_check) -> set[str]:
+        """Probes various GET endpoints to determine read scopes of the token.
+
+        Args:
+            has_private_repo_access (bool): Whether we have access to at least one private repo.
+
+        Returns:
+            Set[str]: Set of available scope names.
+        """
+
+        repo_data = await self.api.call_get(f"/repos/{repo_to_check}")
+        if repo_data.json().get("private"):
+            private_probes = True
+        else:
+            private_probes = False
+
+        valid_scopes = set()
+
+        # Full set of probes for tokens with private repo access
+        private_probe_map = {
+            "contents:read": f"/repos/{repo_to_check}/commits",  # Repository contents
+            "issues:read": f"/repos/{repo_to_check}/issues",  # Issues
+            "pull_requests:read": f"/repos/{repo_to_check}/pulls",  # Pull requests
+            "actions:read": f"/repos/{repo_to_check}/actions/workflows",  # Actions
+            "secrets:read": f"/repos/{repo_to_check}/actions/secrets",  # Secrets
+            "administration:read": f"/repos/{repo_to_check}/actions/permissions",  # Administration
+            "variables:read": f"/repos/{repo_to_check}/actions/variables",  # Variables
+            "deployments:read": f"/repos/{repo_to_check}/deployments",  # Deployments
+            "webhooks:read": f"/repos/{repo_to_check}/hooks",  # Webhooks
+        }
+        public_probe_map = {
+            "administration:read": f"/repos/{repo_to_check}/actions/permissions",  # Administration
+            "secrets:read": f"/repos/{repo_to_check}/actions/secrets",  # Secrets
+            "variables:read": f"/repos/{repo_to_check}/actions/variables",  # Variables
+        }
+
+        if private_probes:
+            probes = private_probe_map
+        else:
+            probes = public_probe_map
+
+        Output.info("Probing endpoints to detect scopes...")
+
+        for scope_name, endpoint in probes.items():
+            try:
+                result = await self.api.call_get(endpoint)
+                has_permission = result.status_code == 200
+
+                if has_permission:
+                    valid_scopes.add(scope_name)
+
+            except Exception as e:
+                Output.tabbed(f" {scope_name}: Error - {str(e)}")
+
+        is_public = not private_probes
+        await self.probe_write_access(repo_to_check, valid_scopes, is_public)
+        await self.probe_actions_write_access(repo_to_check, valid_scopes, is_public)
+        await self.probe_pull_requests_write_access(
+            repo_to_check, valid_scopes, is_public
+        )
+        await self.probe_issue_write_access(repo_to_check, valid_scopes, is_public)
+
+        for scope in sorted(valid_scopes):
+            Output.tabbed(f" {scope} ✅")
+
+        return valid_scopes
+
+    async def enumerate_fine_grained_token(
+        self, enum_mode: str = "self", target_repo: str | None = None
+    ) -> tuple[list[Repository], dict[str, Any]]:
+        """Main enumeration method for fine-grained tokens.
+
+        Args:
+            enum_mode (str): Either "self" for self-enumeration or "single" for single repo.
+            target_repo (Optional[str]): Target repository for single repo mode.
+
+        Returns:
+            Tuple[List[Repository], Dict[str, Any]]: Accessible repositories and enumeration results.
+        """
+        if enum_mode not in ["self", "single"]:
+            raise ValueError("enum_mode must be either 'self' or 'single'")
+
+        if enum_mode == "single" and not target_repo:
+            raise ValueError("target_repo is required for single repo enumeration mode")
+
+        Output.result("Starting fine-grained token enumeration")
+
+        if not await self.validate_token_and_get_user():
+            return [], {}
+
+        public_repos = await self.api.get_own_repos(visibility="public")
+        write_accessible_repos = []
+        if public_repos:
+            Output.info("Checking write+ access to public repositories...")
+            for repo in public_repos:
+                if await self.check_collaborator_access(repo):
+                    write_accessible_repos.append(repo)
+        else:
+            Output.info("No public repositories found")
+
+        private_repos = await self.api.get_own_repos(
+            affiliation="owner,collaborator,organization_member", visibility="private"
+        )
+        has_private_access = len(private_repos) > 0
+
+        if has_private_access:
+            Output.info(f"Token has access to {len(private_repos)} private repo(s).")
+            # Probe scopes on private repo - we just need to check one.
+            # As the fg PAT model means it will be the same for all.
+            self.app_permissions = await self.detect_scopes(private_repos[0])
+        elif write_accessible_repos:
+            Output.info("Token has public repository access only")
+            self.app_permissions = await self.detect_scopes(write_accessible_repos[0])
+        else:
+            Output.info("Token has only public read access!")
+
+        repositories = await self.enumerate_repos(
+            write_accessible_repos + private_repos
+        )
+
+        # Prepare enumeration results
+        enum_results = {
+            "user": self.user_perms,
+            "private_repos": len(private_repos),
+            "write_accessible_repos": len(write_accessible_repos),
+            "valid_scopes": self.app_permissions,
+            "enum_mode": enum_mode,
+        }
+
+        return repositories, enum_results

--- a/gatox/enumerate/recommender.py
+++ b/gatox/enumerate/recommender.py
@@ -8,7 +8,9 @@ from gatox.models.secret import Secret
 
 class Recommender:
     @staticmethod
-    def print_repo_attack_recommendations(scopes: list, repository: Repository):
+    def print_repo_attack_recommendations(
+        scopes: list, repository: Repository, fine_grained: set = {}
+    ):
         """Prints attack recommendations for repositories.
 
         Args:
@@ -17,7 +19,11 @@ class Recommender:
         """
 
         if not repository.sh_runner_access:
-            if repository.is_admin():
+            if (
+                repository.is_admin()
+                and not fine_grained
+                or "administration:read" in fine_grained
+            ):
                 Output.owned(
                     "The user is an administrator on the repository, but no "
                     "self-hosted runners were detected!"
@@ -30,6 +36,11 @@ class Recommender:
                 Output.result(
                     "The PAT also has the workflow scope, which means a "
                     "custom YAML payload can be used!"
+                )
+            elif fine_grained:
+                Output.result(
+                    "The PAT is a fine-grained token, so you will have to overtly check whether"
+                    "it has the 'workflow' permission!"
                 )
             else:
                 Output.inform(

--- a/gatox/enumerate/recommender.py
+++ b/gatox/enumerate/recommender.py
@@ -98,12 +98,13 @@ class Recommender:
                 )
 
     @staticmethod
-    def print_repo_secrets(scopes, secrets: list[Secret]):
+    def print_repo_secrets(scopes, secrets: list[Secret], app_permissions=None):
         """Prints list of repository level secrets.
 
         Args:
             scopes (list): List of OAuth scopes.
             secrets (list[Secret]): List of secret wrapper objects.
+            app_permissions (set, optional): Set of app permissions for fine-grained tokens.
         """
 
         if not secrets:

--- a/gatox/enumerate/repository.py
+++ b/gatox/enumerate/repository.py
@@ -57,7 +57,9 @@ class RepositoryEnum:
 
         return runner_detected
 
-    async def enumerate_repository(self, repository: Repository):
+    async def enumerate_repository(
+        self, repository: Repository, fine_grained: set = {}
+    ):
         """Enumerate a repository, and check everything relevant to
         self-hosted runner abuse that that the user has permissions to check.
 
@@ -75,9 +77,10 @@ class RepositoryEnum:
             for risk in repository.get_risks():
                 ActionsReport.report_actions_risk(risk)
 
-        if repository.is_admin():
+        if repository.is_admin() and (
+            not fine_grained or "administration:read" in fine_grained
+        ):
             runners = await self.api.get_repo_runners(repository.name)
-
             if runners:
                 repo_runners = [
                     Runner(

--- a/unit_test/test_cli.py
+++ b/unit_test/test_cli.py
@@ -41,7 +41,7 @@ async def test_cli_fine_grained_pat(capfd):
     with pytest.raises(SystemExit):
         await cli.cli(["enumerate", "-t", "test"])
     out, err = capfd.readouterr()
-    assert "not supported" in err
+    assert "unsupported" in err
 
 
 async def test_cli_s2s_token(capfd):

--- a/unit_test/test_finegrained_enumeration_simple.py
+++ b/unit_test/test_finegrained_enumeration_simple.py
@@ -1,0 +1,358 @@
+import json
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gatox.caching.cache_manager import CacheManager
+from gatox.cli.output import Output
+from gatox.enumerate.finegrained_enumeration import FineGrainedEnumerator
+from gatox.github.api import Api
+from unit_test.utils import escape_ansi
+
+Output(True)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the CacheManager singleton instance before each test."""
+    CacheManager._instance = None
+    yield
+    CacheManager._instance = None
+
+
+class TestFineGrainedEnumeratorSimple:
+    """Simplified test suite for FineGrainedEnumerator class."""
+
+    @patch("gatox.enumerate.finegrained_enumeration.Api", return_value=AsyncMock(Api))
+    def test_init(self, mock_api):
+        """Test FineGrainedEnumerator initialization."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            socks_proxy=None,
+            http_proxy="localhost:8080",
+            skip_log=False,
+        )
+
+        assert enumerator.http_proxy == "localhost:8080"
+        assert enumerator.accessible_repos == []
+
+    async def test_probe_write_access_success(self):
+        """Test successful write access probing."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        enumerator.api.call_post = AsyncMock(return_value=mock_response)
+
+        valid_scopes = {"contents:read"}
+
+        await enumerator.probe_write_access("octocat/Hello-World", valid_scopes, False)
+
+        assert "contents:read" not in valid_scopes
+        assert "contents:write" in valid_scopes
+        enumerator.api.call_post.assert_called_once()
+
+    async def test_probe_write_access_failure(self):
+        """Test failed write access probing."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        enumerator.api.call_post = AsyncMock(return_value=mock_response)
+
+        valid_scopes = {"contents:read"}
+        original_scopes = valid_scopes.copy()
+
+        await enumerator.probe_write_access("octocat/Hello-World", valid_scopes, False)
+
+        # Scopes should remain unchanged on failure
+        assert valid_scopes == original_scopes
+
+    async def test_probe_write_access_public_repo(self):
+        """Test write access probing for public repository without read permission."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        enumerator.api.call_post = AsyncMock(return_value=mock_response)
+
+        valid_scopes = set()  # No read permissions
+
+        await enumerator.probe_write_access(
+            "octocat/Hello-World", valid_scopes, is_public=True
+        )
+
+        assert "contents:write" in valid_scopes
+        enumerator.api.call_post.assert_called_once()
+
+    async def test_probe_write_access_no_permission_not_public(self):
+        """Test write access probing when no read permission and not public repo."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+        enumerator.api.call_post = AsyncMock()
+
+        valid_scopes = set()  # No permissions
+
+        await enumerator.probe_write_access(
+            "octocat/Hello-World", valid_scopes, is_public=False
+        )
+
+        # Should not make any API calls or modify scopes
+        enumerator.api.call_post.assert_not_called()
+        assert len(valid_scopes) == 0
+
+    async def test_probe_pull_requests_write_access(self):
+        """Test pull requests write access probing."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+
+        # Mock PR list response
+        pr_list_response = MagicMock()
+        pr_list_response.status_code = 200
+        pr_list_response.json.return_value = [{"number": 1}]
+
+        # Mock successful PATCH response
+        patch_response = MagicMock()
+        patch_response.status_code = 200
+
+        enumerator.api.call_get = AsyncMock(return_value=pr_list_response)
+        enumerator.api.call_patch = AsyncMock(return_value=patch_response)
+
+        valid_scopes = {"pull_requests:read"}
+
+        await enumerator.probe_pull_requests_write_access(
+            "octocat/Hello-World", valid_scopes, False
+        )
+
+        assert "pull_requests:read" not in valid_scopes
+        assert "pull_requests:write" in valid_scopes
+
+    async def test_probe_actions_write_access(self):
+        """Test actions write access probing via OIDC settings."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+
+        # Mock OIDC get response
+        get_response = MagicMock()
+        get_response.status_code = 200
+        get_response.json.return_value = {"use_default": True}
+
+        # Mock OIDC put response
+        put_response = MagicMock()
+        put_response.status_code = 204
+
+        enumerator.api.call_get = AsyncMock(return_value=get_response)
+        enumerator.api.call_put = AsyncMock(return_value=put_response)
+
+        valid_scopes = {"actions:read"}
+
+        await enumerator.probe_actions_write_access(
+            "octocat/Hello-World", valid_scopes, False
+        )
+
+        assert "actions:write" in valid_scopes
+        assert "actions:read" not in valid_scopes
+
+    async def test_probe_issue_write_access(self):
+        """Test issues write access probing."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+
+        # Mock issue list response
+        issue_list_response = MagicMock()
+        issue_list_response.status_code = 200
+        issue_list_response.json.return_value = [{"number": 1}]
+
+        # Mock successful PATCH response
+        patch_response = MagicMock()
+        patch_response.status_code = 200
+
+        enumerator.api.call_get = AsyncMock(return_value=issue_list_response)
+        enumerator.api.call_patch = AsyncMock(return_value=patch_response)
+
+        valid_scopes = {"issues:read"}
+
+        await enumerator.probe_issue_write_access(
+            "octocat/Hello-World", valid_scopes, False
+        )
+
+        assert "issues:read" not in valid_scopes
+        assert "issues:write" in valid_scopes
+
+    async def test_check_collaborator_access_success(self):
+        """Test successful collaborator access check."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        enumerator.api.call_get = AsyncMock(return_value=mock_response)
+
+        result = await enumerator.check_collaborator_access("octocat/Hello-World")
+
+        assert result is True
+        enumerator.api.call_get.assert_called_once_with(
+            "/repos/octocat/Hello-World/collaborators"
+        )
+
+    async def test_check_collaborator_access_forbidden(self):
+        """Test collaborator access check with 403 response."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        enumerator.api.call_get = AsyncMock(return_value=mock_response)
+
+        result = await enumerator.check_collaborator_access("octocat/Hello-World")
+
+        assert result is False
+
+    def test_enumerate_fine_grained_token_invalid_mode(self):
+        """Test fine-grained token enumeration with invalid mode."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        with pytest.raises(
+            ValueError, match="enum_mode must be either 'self' or 'single'"
+        ):
+            # Use a sync context manager to test the validation
+            import asyncio
+
+            asyncio.run(enumerator.enumerate_fine_grained_token("invalid", None))
+
+    def test_enumerate_fine_grained_token_single_mode_no_repo(self):
+        """Test fine-grained token enumeration in single mode without target repo."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        with pytest.raises(
+            ValueError, match="target_repo is required for single repo enumeration mode"
+        ):
+            import asyncio
+
+            asyncio.run(enumerator.enumerate_fine_grained_token("single", None))
+
+    async def test_error_handling_in_probes(self):
+        """Test error handling in various probe functions."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API to raise exceptions
+        enumerator.api = MagicMock()
+        enumerator.api.call_post = AsyncMock(side_effect=Exception("Network error"))
+        enumerator.api.call_get = AsyncMock(side_effect=Exception("Network error"))
+        enumerator.api.call_patch = AsyncMock(side_effect=Exception("Network error"))
+        enumerator.api.call_put = AsyncMock(side_effect=Exception("Network error"))
+
+        valid_scopes = {
+            "contents:read",
+            "issues:read",
+            "pull_requests:read",
+            "actions:read",
+        }
+        expected_scopes = valid_scopes.copy()
+
+        # These should not raise exceptions, just handle gracefully
+        await enumerator.probe_write_access("octocat/Hello-World", valid_scopes, False)
+        await enumerator.probe_pull_requests_write_access(
+            "octocat/Hello-World", valid_scopes, False
+        )
+        await enumerator.probe_actions_write_access(
+            "octocat/Hello-World", valid_scopes, False
+        )
+        await enumerator.probe_issue_write_access(
+            "octocat/Hello-World", valid_scopes, False
+        )
+
+        # Scopes should remain unchanged due to errors
+        assert valid_scopes == expected_scopes
+
+    async def test_detect_scopes_integration_mocked(self):
+        """Integration test for detect_scopes with mocked API responses."""
+        enumerator = FineGrainedEnumerator(
+            pat="github_pat_11ABCDEFG123456789_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+
+        # Mock the API
+        enumerator.api = MagicMock()
+
+        # Mock repo data call for private repo
+        repo_response = MagicMock()
+        repo_response.json.return_value = {"private": True}
+        repo_response.status_code = 200
+
+        # Mock successful responses for all calls
+        success_200 = MagicMock()
+        success_200.status_code = 200
+        success_200.json.return_value = [{"number": 1}]  # For PR/issue lists
+
+        success_201 = MagicMock()
+        success_201.status_code = 201  # For blob creation
+
+        success_204 = MagicMock()
+        success_204.status_code = 204  # For OIDC updates
+
+        # Set up mocking - first call returns repo data, rest return success
+        def get_side_effect(*args, **kwargs):
+            if "/repos/octocat/private-repo" == args[0] and len(args) == 1:
+                return repo_response
+            return success_200
+
+        enumerator.api.call_get = AsyncMock(side_effect=get_side_effect)
+        enumerator.api.call_post = AsyncMock(return_value=success_201)
+        enumerator.api.call_patch = AsyncMock(return_value=success_200)
+        enumerator.api.call_put = AsyncMock(return_value=success_204)
+
+        result = await enumerator.detect_scopes("octocat/private-repo")
+
+        # Should have both read and write permissions
+        expected_write_scopes = {
+            "contents:write",
+            "issues:write",
+            "pull_requests:write",
+            "actions:write",
+        }
+
+        # Check that we have write permissions (which means write probes succeeded)
+        assert expected_write_scopes.issubset(
+            result
+        ), f"Expected {expected_write_scopes} to be subset of {result}"


### PR DESCRIPTION
## Pull Request Overview

This pull request adds a new Gato-X feature to enumerate fine-grained personal access tokens in self-enumeration mode (for now).

Fine-Grained PATs are harder to enumerate because they do not offer scope introspection. As a result, we need to use heuristics to determine which resources a fine-grained token has access to.

For now, we will focus on Fine-Grained PATs with access to repository resources.

## What does this PR add/solve?

Users express a desire to be able to enumerate FG PATs, such as in #186.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security enhancement
- [ ] CI/CD improvement

### Areas affected
- [x] Enumeration functionality
- [ ] Attack/Exploitation features
- [x] GitHub API integration
- [ ] Workflow analysis
- [ ] Runner detection
- [ ] MCP Server
- [x] CLI/User interface
- [ ] Documentation
- [x] Tests
- [ ] Configuration

## Testing Steps

Tested by creating a fine-grained PAT with access to public and private repos and varying scopes. Confirmed that discovery worked as well as the probing functionality.

### Manual Testing
1. 
2. 
3. 

### Automated Testing
- [x] All existing unit tests pass
- [x] New unit tests added for new functionality
- [ ] Integration tests updated/added if applicable
- [x] Code coverage maintained or improved

### Testing Commands
```bash
# Add specific commands to test this PR
# Example:
# python -m pytest unit_test/test_new_feature.py
# python -m gatox enumerate --help
```

## Security Considerations

This PR adds a very small mutating operation (creating a git blob) to the enumeration flow. As of now, this operation does not generate an audit log event and creating a small text blob in a repo is nearly a no-op.

- [ ] This change does not introduce new security risks
- [x] This change has been reviewed for potential security vulnerabilities
- [ ] This change improves existing security measures
- [ ] N/A - No security implications

## Documentation

<!-- Check all that apply -->

- [x] Code changes are documented with appropriate comments
- [ ] Public API changes are documented
- [ ] README.md updated if needed
- [x] Documentation site updated if needed (docs/ folder)
- [ ] CHANGELOG.md updated if applicable

## Checklist

<!-- Please check all applicable items -->

- [ ] My code follows the project's coding style and conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information that might be helpful for reviewers -->

### Screenshots (if applicable)

<img width="614" height="356" alt="image" src="https://github.com/user-attachments/assets/3ec8e351-7c1a-4162-b7bf-69a915f52c7e" />

### Performance Impact
<!-- Describe any performance implications of this change -->

### Breaking Changes
<!-- If this is a breaking change, describe what users need to do to adapt -->

### Related Issues/PRs
<!-- Link to related issues or PRs -->

Closes #186
Related to #
