### PR TITLE
feat(attack): use deployment false similar to teampcp ITW payload

### DIFF
--- a/gatox/attack/oidc/oidc_attack.py
+++ b/gatox/attack/oidc/oidc_attack.py
@@ -87,11 +87,24 @@ class OIDCAttack(Attacker):
                 for env in environments
             ]
             test_job["strategy"] = {"matrix": {"include": matrix_include}}
-            test_job["environment"] = "${{ matrix.environment }}"
+            test_job["environment"] = {
+                "name": "${{ matrix.environment }}",
+                "deployment": False,
+            }
 
         yaml_file["jobs"] = {"testing": test_job}
 
-        return yaml.dump(yaml_file, sort_keys=False)
+        class _OIDCDumper(yaml.Dumper):
+            pass
+
+        _OIDCDumper.add_representer(
+            bool,
+            lambda dumper, data: dumper.represent_scalar(
+                "tag:yaml.org,2002:str", "true" if data else "false", style=""
+            ),
+        )
+
+        return yaml.dump(yaml_file, sort_keys=False, Dumper=_OIDCDumper)
 
     @staticmethod
     def _decode_jwt_claims(token: str):

--- a/unit_test/test_oidc_attack.py
+++ b/unit_test/test_oidc_attack.py
@@ -54,7 +54,8 @@ def test_create_oidc_exfil_yaml_environments():
     assert "production" in yaml_str
     assert "staging" in yaml_str
     assert "files-${{ matrix.safe_name }}" in yaml_str
-    assert "environment: ${{ matrix.environment }}" in yaml_str
+    assert "name: ${{ matrix.environment }}" in yaml_str
+    assert "deployment: false" in yaml_str
 
 
 def test_decode_jwt_claims():


### PR DESCRIPTION
## Summary

Minor update to OIDC dumper to use `deployment: false`

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Other

## Testing

<!-- How did you verify this works? -->

## Notes

<!-- Anything reviewers should know (security implications, breaking changes, etc.) -->

Closes #
