### PR TITLE
feat(enumerate): add --local PATH for offline workflow scanning (#256)

### DIFF
--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -128,6 +128,11 @@ def validate_arguments(args, parser):
     if hasattr(args, "app") and args.app is not None:
         # App command uses App ID + PEM file instead of GH_TOKEN
         gh_token = None  # App command doesn't use this
+    elif getattr(args, "local", None):
+        # Local-only enumeration: no GitHub token is required because the
+        # local enumerator never reaches out to the API. Allow it to be
+        # absent without prompting.
+        gh_token = os.environ.get("GH_TOKEN")
     else:
         # Regular commands need GH_TOKEN
         if "GH_TOKEN" not in os.environ:
@@ -494,8 +499,26 @@ async def enumerate_classic(args, parser):
 async def enumerate(args, parser):
     parser = parser.choices["enumerate"]
 
-    if not (
+    local_path = getattr(args, "local", None)
+
+    # --local is mutually exclusive with all GitHub-API enumeration modes.
+    if local_path and (
         args.target
+        or args.self_enumeration
+        or args.repository
+        or args.repositories
+        or args.validate
+        or args.commit
+    ):
+        parser.error(
+            f"{Fore.RED}[-]{Style.RESET_ALL} --local cannot be combined with "
+            "--target/-t, --repository/-r, --repositories/-R, "
+            "--self-enumeration, --validate or --commit."
+        )
+
+    if not (
+        local_path
+        or args.target
         or args.self_enumeration
         or args.repository
         or args.repositories
@@ -510,6 +533,7 @@ async def enumerate(args, parser):
     enumeration_count = sum(
         bool(x)
         for x in [
+            local_path,
             args.target,
             args.self_enumeration,
             args.repository or args.commit,  # repository and commit work together
@@ -527,10 +551,57 @@ async def enumerate(args, parser):
         LocalCacheFactory.load_cache_from_file(args.cache_restore_file)
         Output.info(f"Cache restored from file:{args.cache_restore_file}")
 
+    if local_path:
+        await enumerate_local(args, parser)
+        return
+
     if "github_pat" in args.gh_token:
         await enumerate_finegrained(args, parser)
     else:
         await enumerate_classic(args, parser)
+
+
+async def enumerate_local(args, parser):
+    """Drive the offline local-repository enumerator.
+
+    No network requests are issued; checks that depend on the GitHub API are
+    skipped and counted in a banner emitted when the run finishes. This
+    handler exists alongside the classic/fine-grained enumerators so the
+    existing code paths stay untouched.
+    """
+    from gatox.enumerate.local_enumerate import LocalEnumerator
+    from gatox.models.execution import Execution
+
+    runner = LocalEnumerator(
+        args.local,
+        recursive=getattr(args, "local_recursive", False),
+        ignore_workflow_run=args.ignore_workflow_run,
+    )
+
+    try:
+        repos = await runner.enumerate()
+    except (FileNotFoundError, NotADirectoryError) as e:
+        parser.error(f"{Fore.RED}[-]{Style.RESET_ALL} {e}")
+        return
+
+    if args.output_yaml:
+        save_workflow_ymls(args.output_yaml)
+
+    exec_wrapper = Execution()
+    exec_wrapper.set_user_details(runner.user_perms)
+    exec_wrapper.add_repositories(repos)
+
+    try:
+        if args.output_json:
+            Output.write_json(exec_wrapper, args.output_json)
+    except Exception:
+        Output.error(
+            "Encountered an error writing the output JSON, this is likely a Gato-X bug."
+        )
+
+    if args.cache_save_file:
+        LocalCacheFactory.dump_cache(args.cache_save_file)
+        Output.info(f"Cache saved to file:{args.cache_save_file}")
 
 
 async def search(args, parser):

--- a/gatox/cli/enumeration/config.py
+++ b/gatox/cli/enumeration/config.py
@@ -128,3 +128,29 @@ def configure_parser_enumerate(parser):
         metavar="JSON_FILE",
         type=WritablePath(),
     )
+
+    parser.add_argument(
+        "--local",
+        "-L",
+        help=(
+            "Scan one or more local repository checkouts instead of calling\n"
+            "the GitHub API. PATH may point to a single repo (containing\n"
+            f".github/workflows/) or to a parent directory holding multiple\n"
+            "repository sub-directories. No network requests are made; checks\n"
+            "that require the GitHub API are skipped and counted in a banner.\n"
+            f"GH_TOKEN is {Output.bright('not')} required when only --local is used."
+        ),
+        metavar=f"{Fore.RED}PATH{Style.RESET_ALL}",
+        type=StringType(4096),
+    )
+
+    parser.add_argument(
+        "--local-recursive",
+        help=(
+            "When used with --local, recursively descend into the local PATH\n"
+            "looking for repositories with .github/workflows/ instead of only\n"
+            "checking immediate subdirectories."
+        ),
+        action="store_true",
+        default=False,
+    )

--- a/gatox/enumerate/local_enumerate.py
+++ b/gatox/enumerate/local_enumerate.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from gatox.caching.cache_manager import CacheManager
 from gatox.cli.output import Output
 from gatox.enumerate.recommender import Recommender
+from gatox.github.api import Api
 from gatox.models.repository import Repository
 from gatox.models.workflow import Workflow
 from gatox.workflow_graph.graph_builder import WorkflowGraphBuilder
@@ -51,7 +52,7 @@ _GITHUB_ORIGIN_RE = re.compile(
 )
 
 
-class LocalApiStub:
+class LocalApiStub(Api):
     """No-op stand-in for ``gatox.github.api.Api`` used by the local enumerator.
 
     Every method that the workflow graph builder or visitors might call against
@@ -59,12 +60,28 @@ class LocalApiStub:
     never makes a network request. Each call emits a DEBUG-level log line
     naming the check that was skipped and increments a counter that the
     enumerator uses to report a summary banner.
+
+    Subclasses :class:`Api` so that the stub satisfies static type checks at
+    call sites that expect an ``Api`` instance (e.g.
+    ``VisitorUtils.add_repo_results``). The parent ``__init__`` is intentionally
+    bypassed because we never make network calls and don't want to construct an
+    ``httpx.AsyncClient`` or require a PAT.
     """
 
     def __init__(self):
+        # Skip ``Api.__init__`` on purpose — no network client is created in
+        # local mode. We still set the attributes that downstream code may
+        # touch so that attribute access doesn't surprise callers.
         self.skip_counter: Counter[str] = Counter()
         # Provide token-shape attributes that some callers inspect
         self.is_app = False
+        self.pat = ""
+        self.transport = None
+        self.verify_ssl = True
+        self.headers = {}
+        self.github_url = "https://api.github.com"
+        self.client = None  # type: ignore[assignment]
+        self.app_permissions = None
         # slug -> on-disk repository root. Populated by the LocalEnumerator as
         # repos are loaded so that intra-scan-set action / workflow references
         # can be resolved from the filesystem instead of being skipped.

--- a/gatox/enumerate/local_enumerate.py
+++ b/gatox/enumerate/local_enumerate.py
@@ -1,0 +1,643 @@
+"""
+Copyright 2025, Adnan Khan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from collections import Counter
+from pathlib import Path
+
+from gatox.caching.cache_manager import CacheManager
+from gatox.cli.output import Output
+from gatox.enumerate.recommender import Recommender
+from gatox.models.repository import Repository
+from gatox.models.workflow import Workflow
+from gatox.workflow_graph.graph_builder import WorkflowGraphBuilder
+from gatox.workflow_graph.visitors.artifact_poisoning_visitor import (
+    ArtifactPoisoningVisitor,
+)
+from gatox.workflow_graph.visitors.dispatch_toctou_visitor import DispatchTOCTOUVisitor
+from gatox.workflow_graph.visitors.injection_visitor import InjectionVisitor
+from gatox.workflow_graph.visitors.pwn_request_visitor import PwnRequestVisitor
+from gatox.workflow_graph.visitors.review_injection_visitor import (
+    ReviewInjectionVisitor,
+)
+from gatox.workflow_graph.visitors.runner_visitor import RunnerVisitor
+from gatox.workflow_graph.visitors.visitor_utils import VisitorUtils
+
+logger = logging.getLogger(__name__)
+
+# GitHub origin URL patterns - extract owner/repo
+# Matches https://github.com/owner/repo[.git], git@github.com:owner/repo[.git],
+# ssh://git@github.com/owner/repo[.git]
+_GITHUB_ORIGIN_RE = re.compile(
+    r"github\.com[:/]+([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*?)(?:\.git)?/?$"
+)
+
+
+class LocalApiStub:
+    """No-op stand-in for ``gatox.github.api.Api`` used by the local enumerator.
+
+    Every method that the workflow graph builder or visitors might call against
+    a real ``Api`` is implemented here so that the offline enumeration code path
+    never makes a network request. Each call emits a DEBUG-level log line
+    naming the check that was skipped and increments a counter that the
+    enumerator uses to report a summary banner.
+    """
+
+    def __init__(self):
+        self.skip_counter: Counter[str] = Counter()
+        # Provide token-shape attributes that some callers inspect
+        self.is_app = False
+        # slug -> on-disk repository root. Populated by the LocalEnumerator as
+        # repos are loaded so that intra-scan-set action / workflow references
+        # can be resolved from the filesystem instead of being skipped.
+        self._repo_roots: dict[str, Path] = {}
+
+    # --- Skip helpers -----------------------------------------------------
+
+    def _skip(self, kind: str, detail: str) -> None:
+        """Record a skipped API-dependent check.
+
+        Args:
+            kind: Short tag identifying the check class (e.g.
+                ``"external_action_resolution"``). Used for the banner counts.
+            detail: Free-form extra context for the debug log line.
+        """
+        self.skip_counter[kind] += 1
+        logger.debug("[local] skipping %s: %s", kind, detail)
+
+    # --- Local-set registration ------------------------------------------
+
+    def register_repo_root(self, slug: str, root: Path) -> None:
+        """Record an on-disk repository root so that follow-up calls to
+        :meth:`retrieve_raw_action` and :meth:`retrieve_repo_file` can resolve
+        intra-scan-set references locally rather than skipping them.
+        """
+        self._repo_roots[slug] = Path(root)
+
+    def _read_local_file(self, slug: str, path: str) -> str | None:
+        """Best-effort read of ``<repo_root>/<path>`` for a registered repo.
+
+        Composite actions are referenced as a directory (e.g.
+        ``.github/actions/foo``); GitHub then loads ``action.yml`` /
+        ``action.yaml`` inside it. We replicate that lookup here.
+        Returns ``None`` if the repo is not in the scan set or the path is
+        absent on disk.
+        """
+        root = self._repo_roots.get(slug)
+        if not root:
+            return None
+        # The graph builder hands us a relative path; refuse anything that
+        # tries to escape the repo root.
+        rel = Path(path)
+        if rel.is_absolute() or any(part == ".." for part in rel.parts):
+            return None
+        candidate = root / rel
+        try:
+            if candidate.is_file():
+                return candidate.read_text(encoding="utf-8", errors="replace")
+            if candidate.is_dir():
+                for action_name in ("action.yml", "action.yaml"):
+                    inner = candidate / action_name
+                    if inner.is_file():
+                        return inner.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:  # pragma: no cover - defensive
+            logger.debug("[local] read error for %s/%s: %s", slug, path, e)
+        return None
+
+    # --- Authentication / identity stubs ----------------------------------
+
+    def is_app_token(self) -> bool:
+        return False
+
+    async def check_user(self):
+        # Synthetic identity for downstream code that expects a user dict.
+        return {
+            "user": "local-mode",
+            "scopes": [],
+            "name": "Gato-X Local Mode",
+        }
+
+    async def check_organizations(self):
+        self._skip("organization_membership", "not available offline")
+        return []
+
+    # --- Workflow / action retrieval stubs --------------------------------
+
+    async def retrieve_raw_action(self, repo: str, path: str, ref: str):
+        # Try the local scan set first; this lets composite actions that live
+        # inside one of the loaded repos (e.g. ``.github/actions/foo`` in the
+        # same repository) resolve cleanly without API access.
+        contents = self._read_local_file(repo, path)
+        if contents is not None:
+            return contents
+        self._skip(
+            "external_action_resolution",
+            f"action {repo}/{path}@{ref} not available offline",
+        )
+        return None
+
+    async def retrieve_repo_file(self, slug: str, path: str, ref: str):
+        contents = self._read_local_file(slug, path)
+        if contents is not None:
+            return contents
+        self._skip(
+            "callee_workflow_resolution",
+            f"workflow {slug}:{path}@{ref} not in local scan set",
+        )
+        return None
+
+    async def retrieve_workflow_ymls(self, repo_name: str):
+        self._skip("api_workflow_listing", repo_name)
+        return []
+
+    async def retrieve_workflow_ymls_ref(self, repo_name: str, ref: str):
+        self._skip("api_workflow_listing_ref", f"{repo_name}@{ref}")
+        return []
+
+    async def retrieve_workflow_log(self, *args, **kwargs):
+        self._skip("run_log_analysis", "not available offline")
+        return None
+
+    async def retrieve_run_logs(self, repo_name: str, workflows=None):
+        self._skip("run_log_analysis", repo_name)
+        return []
+
+    # --- Branch / repository stubs ----------------------------------------
+
+    async def get_repository(self, repository: str):
+        self._skip("repository_metadata", repository)
+        return None
+
+    async def get_repo_branch(self, repo: str, branch: str):
+        self._skip("branch_lookup", f"{repo}@{branch}")
+        return None
+
+    async def get_repo_runners(self, full_name: str):
+        self._skip("runner_listing", full_name)
+        return []
+
+    async def get_secrets(self, repo_name: str):
+        self._skip("repository_secrets", repo_name)
+        return []
+
+    async def get_environment_secrets(self, repo_name: str, environment_name: str):
+        self._skip("environment_secrets", f"{repo_name}/{environment_name}")
+        return []
+
+    async def get_repo_org_secrets(self, repo_name: str):
+        self._skip("org_secrets", repo_name)
+        return []
+
+    async def get_all_environment_protection_rules(self, repo_name: str):
+        self._skip("branch_protection_rules", repo_name)
+        return []
+
+    async def get_file_last_updated(self, repo_name: str, file_path: str):
+        self._skip("commit_history", f"{repo_name}:{file_path}")
+        return (None, None, None)
+
+    async def get_commit_merge_date(self, repo_name: str, sha: str):
+        self._skip("commit_merge_date", f"{repo_name}@{sha}")
+        return None
+
+    async def get_user_type(self, username: str):
+        self._skip("user_type_lookup", username)
+        return None
+
+    async def call_get(self, *args, **kwargs):
+        self._skip("raw_api_get", str(args[:1]))
+        return None
+
+    async def call_post(self, *args, **kwargs):
+        self._skip("raw_api_post", str(args[:1]))
+        return None
+
+
+# --- .git/config helpers ---------------------------------------------------
+
+
+def parse_origin_url(config_text: str) -> tuple[str, str] | None:
+    """Parse a ``.git/config`` blob and extract the GitHub ``owner/repo`` from
+    the ``[remote "origin"]`` section.
+
+    Args:
+        config_text: Raw contents of the repository's ``.git/config`` file.
+
+    Returns:
+        ``(owner, name)`` tuple if a GitHub origin URL is found, else ``None``.
+    """
+    in_origin = False
+    url: str | None = None
+    for raw_line in config_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            # Section header, e.g. [remote "origin"] or [remote "origin"] etc.
+            in_origin = bool(
+                re.match(r'^\[remote\s+"origin"\]$', line)
+                or line == '[remote "origin"]'
+            )
+            continue
+        if in_origin and line.lower().startswith("url"):
+            # Format is `url = <value>`
+            parts = line.split("=", 1)
+            if len(parts) == 2:
+                url = parts[1].strip()
+                break
+
+    if not url:
+        return None
+
+    match = _GITHUB_ORIGIN_RE.search(url)
+    if not match:
+        return None
+    owner, name = match.group(1), match.group(2)
+    # Strip a trailing .git that may have slipped past
+    if name.endswith(".git"):
+        name = name[:-4]
+    return owner, name
+
+
+def detect_default_branch(git_dir: Path) -> str:
+    """Best-effort default branch detection from ``.git/HEAD``.
+
+    Falls back to ``"main"`` if HEAD is detached or unreadable.
+    """
+    head_path = git_dir / "HEAD"
+    try:
+        content = head_path.read_text(encoding="utf-8", errors="replace").strip()
+        if content.startswith("ref:"):
+            ref = content.split(maxsplit=1)[1].strip()
+            if ref.startswith("refs/heads/"):
+                return ref[len("refs/heads/") :]
+    except OSError:
+        pass
+    return "main"
+
+
+def repo_identity(repo_dir: Path) -> tuple[str, str, bool]:
+    """Determine the ``owner/name`` slug for a local repo directory.
+
+    Args:
+        repo_dir: Path to the repository root (the directory that
+            contains ``.git`` and/or ``.github/workflows``).
+
+    Returns:
+        ``(slug, default_branch, synthetic)`` where ``slug`` is the
+        ``owner/name`` identifier used everywhere downstream, ``default_branch``
+        is the working branch name to attach to workflows, and ``synthetic``
+        is True iff the slug was not derived from a real GitHub origin URL.
+    """
+    git_dir = repo_dir / ".git"
+    config = git_dir / "config"
+    if config.is_file():
+        try:
+            text = config.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            logger.debug("[local] could not read %s: %s", config, e)
+            text = ""
+        parsed = parse_origin_url(text)
+        if parsed:
+            owner, name = parsed
+            return f"{owner}/{name}", detect_default_branch(git_dir), False
+
+    # Synthetic name fallback - use the directory name with a clear local prefix.
+    fallback = f"local::{repo_dir.name}"
+    branch = detect_default_branch(git_dir) if git_dir.is_dir() else "main"
+    return fallback, branch, True
+
+
+# --- Workflow discovery ----------------------------------------------------
+
+
+def _is_workflow_file(name: str) -> bool:
+    lowered = name.lower()
+    return lowered.endswith(".yml") or lowered.endswith(".yaml")
+
+
+def _has_workflows(path: Path) -> bool:
+    wf_dir = path / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        return False
+    return any(_is_workflow_file(p.name) for p in wf_dir.iterdir() if p.is_file())
+
+
+def discover_repos(root: Path, recursive: bool = False) -> list[Path]:
+    """Discover repository roots under ``root``.
+
+    Detection rules (matching the locked-in UX):
+      * If ``root`` itself contains ``.github/workflows/*.yml`` it is treated
+        as a single repository.
+      * Otherwise, immediate subdirectories of ``root`` are inspected and any
+        that contain ``.github/workflows/*.yml`` are returned.
+      * When ``recursive=True`` the search descends further (depth-first) and
+        returns every directory below ``root`` that has a workflows folder.
+    """
+    if not root.exists():
+        raise FileNotFoundError(f"Local scan root does not exist: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"Local scan root is not a directory: {root}")
+
+    if _has_workflows(root):
+        return [root]
+
+    discovered: list[Path] = []
+    if recursive:
+        for dirpath, dirnames, _ in os.walk(root):
+            # Don't descend into .git or virtualenvs
+            dirnames[:] = [
+                d for d in dirnames if d not in {".git", ".venv", "node_modules"}
+            ]
+            if _has_workflows(Path(dirpath)):
+                discovered.append(Path(dirpath))
+    else:
+        for child in sorted(root.iterdir()):
+            if child.is_dir() and _has_workflows(child):
+                discovered.append(child)
+
+    return discovered
+
+
+def _build_local_repo_data(slug: str, default_branch: str) -> dict:
+    """Build a minimal ``Repository`` constructor dict for an offline scan.
+
+    The downstream wrappers expect these keys; we mark permissions as
+    read-only and set defaults for fields that only matter when calling the
+    GitHub API (push timestamp, fork status, ...).
+    """
+    return {
+        "full_name": slug,
+        "html_url": f"local://{slug}",
+        "visibility": "public",
+        "default_branch": default_branch,
+        "fork": False,
+        "stargazers_count": 0,
+        "pushed_at": None,
+        "permissions": {
+            "pull": True,
+            "push": False,
+            "maintain": False,
+            "admin": False,
+        },
+        "archived": False,
+        "isFork": False,
+        "allow_forking": False,
+        "environments": [],
+    }
+
+
+# --- Enumerator ------------------------------------------------------------
+
+
+class LocalEnumerator:
+    """Offline workflow enumeration driver.
+
+    Walks one or more local repositories, loads their workflow YAMLs into the
+    in-memory cache, drives the existing graph builder and visitor pipeline,
+    then prints findings in the same format as the API-mode enumerator. No
+    network requests are performed; every API-dependent check is logged as a
+    debug-level skip via ``LocalApiStub``.
+    """
+
+    def __init__(
+        self,
+        local_path: str | os.PathLike,
+        recursive: bool = False,
+        ignore_workflow_run: bool = False,
+        skip_log: bool = True,
+    ):
+        self.local_path = Path(local_path).expanduser().resolve()
+        self.recursive = recursive
+        self.ignore_workflow_run = ignore_workflow_run
+        # ``skip_log`` mirrors the API-mode flag; runlog analysis is always
+        # API-only so we force-default to True but expose the knob for parity.
+        self.skip_log = True if skip_log is None else skip_log
+        self.api = LocalApiStub()
+        self.user_perms: dict | None = None
+        self._loaded_repos: list[Repository] = []
+        self._loaded_workflow_count = 0
+
+    # ---- discovery + loading ------------------------------------------------
+
+    def _load_workflow_files(self, repo_dir: Path, repo: Repository) -> list[Workflow]:
+        """Read every workflow YAML for ``repo_dir`` into the cache and the graph.
+
+        The same workflow is registered twice in the cache: once under its bare
+        filename (matching the API-mode key shape used by
+        :class:`DataIngestor.construct_workflow_cache`) and once under the
+        ``<path>:<ref>`` key shape consulted by the graph builder when
+        resolving callee references. Storing both ensures cross-repo
+        ``workflow_call`` / ``workflow_run`` stitching works whenever both
+        endpoints are inside the local scan set.
+        """
+        wf_dir = repo_dir / ".github" / "workflows"
+        cache = CacheManager()
+        loaded: list[Workflow] = []
+        cache.set_empty(repo.name)
+
+        if not wf_dir.is_dir():
+            return loaded
+
+        for yml in sorted(wf_dir.iterdir()):
+            if not yml.is_file() or not _is_workflow_file(yml.name):
+                continue
+            try:
+                contents = yml.read_text(encoding="utf-8", errors="replace")
+            except OSError as e:
+                logger.warning("[local] could not read %s: %s", yml, e)
+                continue
+
+            wf = Workflow(
+                repo.name,
+                contents,
+                yml.name,
+                default_branch=repo.repo_data["default_branch"],
+            )
+            if wf.isInvalid():
+                logger.debug(
+                    "[local] skipping invalid workflow YAML %s in %s",
+                    yml.name,
+                    repo.name,
+                )
+                continue
+
+            cache.set_workflow(repo.name, wf.workflow_name, wf)
+            # Also store under the callee key shape so cross-repo
+            # workflow_call lookups inside the graph builder hit the cache
+            # instead of the LocalApiStub. The graph builder uses
+            # ``f"{path}:{ref}"`` as its workflow cache key.
+            callee_key = f"{wf.getPath()}:{wf.branch}"
+            cache.set_workflow(repo.name, callee_key, wf)
+            loaded.append(wf)
+        return loaded
+
+    async def _load_repo(self, repo_dir: Path) -> Repository:
+        """Build a Repository wrapper for the given directory and register it."""
+        slug, branch, synthetic = repo_identity(repo_dir)
+        if synthetic:
+            logger.debug(
+                "[local] using synthetic name %s for %s (no GitHub origin)",
+                slug,
+                repo_dir,
+            )
+        repo_data = _build_local_repo_data(slug, branch)
+        repo = Repository(repo_data)
+        CacheManager().set_repository(repo)
+        # Register the on-disk root so the API stub can resolve intra-set
+        # composite actions and reusable workflows from the filesystem.
+        self.api.register_repo_root(slug, repo_dir)
+
+        wfs = self._load_workflow_files(repo_dir, repo)
+        for wf in wfs:
+            await WorkflowGraphBuilder().build_graph_from_yaml(wf, repo)
+        self._loaded_workflow_count += len(wfs)
+        return repo
+
+    # ---- visitor pipeline ---------------------------------------------------
+
+    async def _process_graph(self) -> None:
+        """Run the same visitor stack used by the API enumerator."""
+        Output.info(
+            f"Performing graph analysis on "
+            f"{WorkflowGraphBuilder().graph.number_of_nodes()} nodes!"
+        )
+
+        visitors = [
+            (PwnRequestVisitor, "find_pwn_requests"),
+            (InjectionVisitor, "find_injections"),
+            (ReviewInjectionVisitor, "find_injections"),
+            (DispatchTOCTOUVisitor, "find_dispatch_misconfigurations"),
+            (ArtifactPoisoningVisitor, "find_artifact_poisoning"),
+        ]
+
+        async def run_visitor(visitor_class, visitor_method):
+            visitor = visitor_class()
+            visitor_func = getattr(visitor, visitor_method)
+            try:
+                if visitor_class in (PwnRequestVisitor, InjectionVisitor):
+                    return await visitor_func(
+                        WorkflowGraphBuilder().graph,
+                        self.api,
+                        self.ignore_workflow_run,
+                    )
+                else:
+                    return await visitor_func(WorkflowGraphBuilder().graph, self.api)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.error(f"Error in {visitor_class.__name__}: {e}")
+                return None
+
+        results = await asyncio.gather(
+            *(run_visitor(v, m) for v, m in visitors),
+            return_exceptions=True,
+        )
+
+        for visitor_class, result in zip(visitors, results, strict=False):
+            if result and not isinstance(result, BaseException):
+                await VisitorUtils.add_repo_results(result, self.api)
+            elif isinstance(result, BaseException):  # pragma: no cover
+                logger.error(f"Error in {visitor_class[0].__name__}: {result}")
+
+        # Runner detection from log files is API-only; we still run the graph
+        # tag-based scanner because it works purely off parsed YAML.
+        await RunnerVisitor.find_runner_workflows(WorkflowGraphBuilder().graph)
+        # Note: no run-log analysis - that requires the GitHub API.
+        logger.debug("[local] skipping run-log analysis: not available offline")
+        self.api.skip_counter["run_log_analysis"] += 1
+
+    # ---- public driver ------------------------------------------------------
+
+    async def enumerate(self) -> list[Repository]:
+        """Enumerate every repository discovered under ``self.local_path``.
+
+        Returns:
+            The list of :class:`Repository` wrappers populated with findings.
+        """
+        # Establish the local "user" once so downstream Recommender calls work
+        self.user_perms = await self.api.check_user()
+
+        repo_dirs = discover_repos(self.local_path, recursive=self.recursive)
+        if not repo_dirs:
+            Output.warn(
+                f"No repositories with .github/workflows/ found under "
+                f"{Output.bright(str(self.local_path))}"
+            )
+            return []
+
+        Output.info(
+            f"[local mode] discovered {Output.bright(str(len(repo_dirs)))} "
+            f"repositor{'y' if len(repo_dirs) == 1 else 'ies'} under "
+            f"{Output.bright(str(self.local_path))}"
+        )
+
+        for repo_dir in repo_dirs:
+            repo = await self._load_repo(repo_dir)
+            self._loaded_repos.append(repo)
+
+        Output.info(
+            f"[local mode] loaded {self._loaded_workflow_count} workflow YAML files"
+        )
+
+        await self._process_graph()
+
+        # Emit per-repo recommendations using the same formatter as API mode.
+        for repo in self._loaded_repos:
+            cached = CacheManager().get_repository(repo.name)
+            if not cached:
+                continue
+            Output.tabbed(f"Checking repository: {Output.bright(cached.name)}")
+            if cached.get_risks():
+                from gatox.enumerate.reports.actions import ActionsReport
+
+                for risk in cached.get_risks():
+                    ActionsReport.report_actions_risk(risk)
+
+            # Recommendation prints honor the (empty) scope set so secrets/
+            # runner sections automatically degrade to "skipped" output.
+            try:
+                Recommender.print_repo_attack_recommendations(
+                    self.user_perms["scopes"] if self.user_perms else [],
+                    cached,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("[local] recommender error for %s: %s", cached.name, e)
+
+        # Final banner summarising the offline run.
+        skipped_total = sum(self.api.skip_counter.values())
+        banner = (
+            f"[local mode] {len(self._loaded_repos)} repos scanned offline; "
+            f"{skipped_total} API-dependent checks skipped (see debug log)."
+        )
+        Output.result(banner)
+        # Also write to the canonical info channel so it is captured even
+        # when the rich Output is suppressed (e.g. JSON-only mode).
+        logger.info(banner)
+        return self._loaded_repos
+
+    # ---- introspection (used by tests + caller code) -----------------------
+
+    @property
+    def loaded_repos(self) -> list[Repository]:
+        return list(self._loaded_repos)
+
+    @property
+    def skip_counter(self) -> Counter:
+        return self.api.skip_counter

--- a/unit_test/test_local_enumerate.py
+++ b/unit_test/test_local_enumerate.py
@@ -1,0 +1,513 @@
+"""Unit tests for the offline ``--local`` enumeration mode."""
+
+from __future__ import annotations
+
+import logging
+import os
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from gatox.caching.cache_manager import CacheManager
+from gatox.cli import cli
+from gatox.cli.output import Output
+from gatox.enumerate.local_enumerate import (
+    LocalApiStub,
+    LocalEnumerator,
+    discover_repos,
+    parse_origin_url,
+    repo_identity,
+)
+from gatox.workflow_graph.graph_builder import WorkflowGraphBuilder
+from gatox.workflow_graph.node_factory import NodeFactory
+
+Output(True)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_singletons():
+    """Reset the singletons that the enumeration pipeline mutates."""
+    CacheManager._instance = None
+    WorkflowGraphBuilder._instance = None
+    NodeFactory.NODE_CACHE = {}
+    yield
+    CacheManager._instance = None
+    WorkflowGraphBuilder._instance = None
+    NodeFactory.NODE_CACHE = {}
+
+
+def _write_workflow(repo_dir: Path, name: str, body: str) -> Path:
+    wf_dir = repo_dir / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    path = wf_dir / name
+    path.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return path
+
+
+def _write_git_origin(repo_dir: Path, slug: str, branch: str = "main") -> None:
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir(parents=True, exist_ok=True)
+    (git_dir / "config").write_text(
+        f'[remote "origin"]\n\turl = https://github.com/{slug}.git\n',
+        encoding="utf-8",
+    )
+    (git_dir / "HEAD").write_text(f"ref: refs/heads/{branch}\n", encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# parse_origin_url + repo_identity
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/foo/bar.git", ("foo", "bar")),
+        ("https://github.com/foo/bar", ("foo", "bar")),
+        ("git@github.com:foo/bar.git", ("foo", "bar")),
+        ("ssh://git@github.com/foo/bar.git", ("foo", "bar")),
+        ("https://github.com/foo/bar/", ("foo", "bar")),
+        ("https://github.com/foo-bar/baz_qux.git", ("foo-bar", "baz_qux")),
+    ],
+)
+def test_parse_origin_url_variants(url, expected):
+    cfg = f'[remote "origin"]\n\turl = {url}\n'
+    assert parse_origin_url(cfg) == expected
+
+
+def test_parse_origin_url_ignores_non_origin_remote():
+    cfg = textwrap.dedent("""
+        [remote "upstream"]
+            url = https://github.com/upstream/repo.git
+        [remote "origin"]
+            url = https://example.com/some/internal.git
+        """)
+    assert parse_origin_url(cfg) is None
+
+
+def test_parse_origin_url_non_github_returns_none():
+    cfg = '[remote "origin"]\n\turl = https://gitlab.com/foo/bar.git\n'
+    assert parse_origin_url(cfg) is None
+
+
+def test_repo_identity_uses_origin(tmp_path: Path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    _write_git_origin(repo, "alpha/beta", branch="dev")
+    slug, branch, synthetic = repo_identity(repo)
+    assert slug == "alpha/beta"
+    assert branch == "dev"
+    assert synthetic is False
+
+
+def test_repo_identity_falls_back_to_synthetic(tmp_path: Path):
+    repo = tmp_path / "no-git-here"
+    repo.mkdir()
+    slug, branch, synthetic = repo_identity(repo)
+    assert slug == "local::no-git-here"
+    assert branch == "main"
+    assert synthetic is True
+
+
+def test_repo_identity_synthetic_when_origin_is_non_github(tmp_path: Path):
+    repo = tmp_path / "weird"
+    repo.mkdir()
+    git_dir = repo / ".git"
+    git_dir.mkdir()
+    (git_dir / "config").write_text(
+        '[remote "origin"]\n\turl = https://gitlab.com/x/y.git\n',
+        encoding="utf-8",
+    )
+    (git_dir / "HEAD").write_text("ref: refs/heads/trunk\n", encoding="utf-8")
+    slug, branch, synthetic = repo_identity(repo)
+    assert slug == "local::weird"
+    assert branch == "trunk"
+    assert synthetic is True
+
+
+# --------------------------------------------------------------------------
+# discover_repos
+# --------------------------------------------------------------------------
+
+
+def test_discover_single_repo(tmp_path: Path):
+    repo = tmp_path
+    _write_workflow(repo, "ci.yml", "name: x\non: push\njobs: {}\n")
+    found = discover_repos(repo)
+    assert found == [repo]
+
+
+def test_discover_multi_repo_dir(tmp_path: Path):
+    a = tmp_path / "alpha"
+    b = tmp_path / "bravo"
+    c = tmp_path / "charlie"
+    a.mkdir()
+    b.mkdir()
+    c.mkdir()
+    _write_workflow(a, "a.yml", "name: a\non: push\njobs: {}\n")
+    _write_workflow(b, "b.yml", "name: b\non: push\njobs: {}\n")
+    # charlie has no workflows -> excluded
+    found = discover_repos(tmp_path)
+    assert sorted(found) == sorted([a, b])
+
+
+def test_discover_recursive(tmp_path: Path):
+    nested = tmp_path / "outer" / "inner" / "repo"
+    nested.mkdir(parents=True)
+    _write_workflow(nested, "x.yml", "name: x\non: push\njobs: {}\n")
+    # Non-recursive must miss the nested repo
+    assert discover_repos(tmp_path) == []
+    # Recursive picks it up
+    assert discover_repos(tmp_path, recursive=True) == [nested]
+
+
+def test_discover_missing_root_raises(tmp_path: Path):
+    missing = tmp_path / "nope"
+    with pytest.raises(FileNotFoundError):
+        discover_repos(missing)
+
+
+# --------------------------------------------------------------------------
+# LocalApiStub records skips
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_api_stub_skip_logging(caplog):
+    caplog.set_level(logging.DEBUG, logger="gatox.enumerate.local_enumerate")
+    stub = LocalApiStub()
+    await stub.retrieve_raw_action("foo/bar", "action.yml", "main")
+    await stub.retrieve_repo_file("foo/bar", "x.yml", "v1")
+    await stub.get_all_environment_protection_rules("foo/bar")
+    await stub.get_secrets("foo/bar")
+
+    assert stub.is_app_token() is False
+    assert stub.skip_counter["external_action_resolution"] == 1
+    assert stub.skip_counter["callee_workflow_resolution"] == 1
+    assert stub.skip_counter["branch_protection_rules"] == 1
+    assert stub.skip_counter["repository_secrets"] == 1
+
+    msgs = " ".join(rec.message for rec in caplog.records)
+    assert "external_action_resolution" in msgs
+    assert "callee_workflow_resolution" in msgs
+    assert "branch_protection_rules" in msgs
+    assert "repository_secrets" in msgs
+
+
+@pytest.mark.asyncio
+async def test_local_api_stub_resolves_registered_repo(tmp_path):
+    """Intra-scan-set composite actions and reusable workflows resolve from
+    the filesystem instead of falling through to the skip path."""
+    repo_dir = tmp_path / "myrepo"
+    (repo_dir / ".github" / "actions" / "setup").mkdir(parents=True)
+    (repo_dir / ".github" / "actions" / "setup" / "action.yml").write_text(
+        "name: setup\nruns:\n  using: composite\n  steps: []\n", encoding="utf-8"
+    )
+    (repo_dir / ".github" / "workflows").mkdir(parents=True)
+    (repo_dir / ".github" / "workflows" / "reusable.yml").write_text(
+        "on: workflow_call\njobs: {}\n", encoding="utf-8"
+    )
+
+    stub = LocalApiStub()
+    stub.register_repo_root("foo/bar", repo_dir)
+
+    # Composite action lookup resolves directory -> action.yml.
+    contents = await stub.retrieve_raw_action(
+        "foo/bar", ".github/actions/setup", "main"
+    )
+    assert contents is not None and "composite" in contents
+
+    # Direct file lookup also works.
+    contents = await stub.retrieve_repo_file(
+        "foo/bar", ".github/workflows/reusable.yml", "main"
+    )
+    assert contents is not None and "workflow_call" in contents
+
+    # No skip counter increments for the local hits.
+    assert stub.skip_counter["external_action_resolution"] == 0
+    assert stub.skip_counter["callee_workflow_resolution"] == 0
+
+    # Unregistered repo still skips.
+    other = await stub.retrieve_raw_action("other/repo", "action.yml", "main")
+    assert other is None
+    assert stub.skip_counter["external_action_resolution"] == 1
+
+
+@pytest.mark.asyncio
+async def test_local_api_stub_rejects_path_traversal(tmp_path):
+    repo_dir = tmp_path / "r"
+    repo_dir.mkdir()
+    (tmp_path / "secret.txt").write_text("DO NOT LEAK", encoding="utf-8")
+
+    stub = LocalApiStub()
+    stub.register_repo_root("foo/bar", repo_dir)
+
+    # Relative parent traversal must not escape the repo root.
+    contents = await stub.retrieve_raw_action("foo/bar", "../secret.txt", "main")
+    assert contents is None
+    # Absolute paths are rejected too.
+    contents = await stub.retrieve_raw_action(
+        "foo/bar", str(tmp_path / "secret.txt"), "main"
+    )
+    assert contents is None
+
+
+# --------------------------------------------------------------------------
+# End-to-end LocalEnumerator
+# --------------------------------------------------------------------------
+
+
+PWN_WORKFLOW = """
+name: vulnerable
+on:
+  pull_request_target:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: echo "${{ github.event.pull_request.title }}"
+"""
+
+
+@pytest.mark.asyncio
+async def test_local_enumerator_scans_single_repo(tmp_path: Path, caplog):
+    repo = tmp_path / "alpha"
+    repo.mkdir()
+    _write_git_origin(repo, "owner/alpha")
+    _write_workflow(repo, "ci.yml", PWN_WORKFLOW)
+
+    caplog.set_level(logging.DEBUG, logger="gatox.enumerate.local_enumerate")
+    enumerator = LocalEnumerator(repo)
+    repos = await enumerator.enumerate()
+
+    assert len(repos) == 1
+    assert repos[0].name == "owner/alpha"
+    # injection visitor should produce at least one finding for this YAML
+    assert repos[0].get_risks(), "expected the injection visitor to flag findings"
+
+    # banner skip counter should include run_log_analysis at minimum
+    assert enumerator.skip_counter["run_log_analysis"] >= 1
+    # debug-level skip lines were emitted
+    assert any(
+        "[local] skipping run-log analysis" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_enumerator_multi_repo_dir(tmp_path: Path):
+    a = tmp_path / "alpha"
+    b = tmp_path / "bravo"
+    a.mkdir()
+    b.mkdir()
+    _write_git_origin(a, "owner/alpha")
+    _write_git_origin(b, "owner/bravo")
+    _write_workflow(a, "ci.yml", PWN_WORKFLOW)
+    _write_workflow(b, "ci.yml", PWN_WORKFLOW)
+
+    enumerator = LocalEnumerator(tmp_path)
+    repos = await enumerator.enumerate()
+
+    names = sorted(r.name for r in repos)
+    assert names == ["owner/alpha", "owner/bravo"]
+
+
+@pytest.mark.asyncio
+async def test_local_enumerator_synthetic_name(tmp_path: Path):
+    repo = tmp_path / "no-origin"
+    repo.mkdir()
+    _write_workflow(
+        repo,
+        "lint.yml",
+        "name: lint\non:\n  push:\njobs:\n  one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+    )
+    enumerator = LocalEnumerator(repo)
+    repos = await enumerator.enumerate()
+    assert len(repos) == 1
+    assert repos[0].name == "local::no-origin"
+
+
+# --------------------------------------------------------------------------
+# Cross-repo stitching: workflow_call + workflow_run
+# --------------------------------------------------------------------------
+
+
+CALLER_WORKFLOW = """
+name: caller
+on:
+  pull_request_target:
+jobs:
+  call:
+    uses: owner/callee/.github/workflows/reusable.yml@main
+    secrets: inherit
+"""
+
+CALLEE_WORKFLOW = """
+name: reusable
+on:
+  workflow_call:
+jobs:
+  do:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.pull_request.title }}"
+"""
+
+
+@pytest.mark.asyncio
+async def test_local_enumerator_workflow_call_cross_repo(tmp_path: Path):
+    caller = tmp_path / "caller"
+    callee = tmp_path / "callee"
+    caller.mkdir()
+    callee.mkdir()
+    _write_git_origin(caller, "owner/caller")
+    _write_git_origin(callee, "owner/callee")
+    _write_workflow(caller, "caller.yml", CALLER_WORKFLOW)
+    _write_workflow(callee, "reusable.yml", CALLEE_WORKFLOW)
+
+    enumerator = LocalEnumerator(tmp_path)
+    repos = await enumerator.enumerate()
+    by_name = {r.name: r for r in repos}
+    assert "owner/caller" in by_name
+    assert "owner/callee" in by_name
+
+    # The callee workflow must NOT have triggered an API lookup for resolution
+    # because it was loaded into the cache from disk. If cross-repo stitching
+    # broke we'd see the "callee_workflow_resolution" skip incremented.
+    assert enumerator.skip_counter.get("callee_workflow_resolution", 0) == 0
+
+
+PRODUCER_WORKFLOW = """
+name: ci
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+"""
+
+CONSUMER_WORKFLOW = """
+name: consumer
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types: [completed]
+jobs:
+  poke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.workflow_run.head_branch }}"
+"""
+
+
+@pytest.mark.asyncio
+async def test_local_enumerator_workflow_run_cross_repo(tmp_path: Path):
+    producer = tmp_path / "producer"
+    consumer = tmp_path / "consumer"
+    producer.mkdir()
+    consumer.mkdir()
+    _write_git_origin(producer, "owner/producer")
+    _write_git_origin(consumer, "owner/consumer")
+    _write_workflow(producer, "ci.yml", PRODUCER_WORKFLOW)
+    _write_workflow(consumer, "consumer.yml", CONSUMER_WORKFLOW)
+
+    enumerator = LocalEnumerator(tmp_path)
+    repos = await enumerator.enumerate()
+    names = sorted(r.name for r in repos)
+    assert names == ["owner/consumer", "owner/producer"]
+
+    # The graph should contain the consumer workflow node tagged workflow_run
+    graph = WorkflowGraphBuilder().graph
+    consumer_workflow_nodes = [
+        n
+        for n in graph.nodes
+        if "WorkflowNode" in n.get_tags()
+        and "workflow_run" in n.get_tags()
+        and "consumer" in n.name
+    ]
+    assert consumer_workflow_nodes, "consumer workflow_run node missing"
+
+
+# --------------------------------------------------------------------------
+# CLI integration tests (validate_arguments / mutex / no-token path)
+# --------------------------------------------------------------------------
+
+
+def _scrub_gh_token():
+    """Helper: ensure GH_TOKEN is unset for this test."""
+    if "GH_TOKEN" in os.environ:
+        del os.environ["GH_TOKEN"]
+
+
+@pytest.mark.asyncio
+async def test_cli_local_no_token_required(tmp_path: Path):
+    """``--local`` must not prompt for or require GH_TOKEN."""
+    repo = tmp_path / "demo"
+    repo.mkdir()
+    _write_git_origin(repo, "owner/demo")
+    _write_workflow(repo, "ci.yml", PWN_WORKFLOW)
+
+    _scrub_gh_token()
+    # If GH_TOKEN were required, ``input`` would be called and SystemExit
+    # would be raised when an invalid placeholder is returned.
+    with mock.patch("builtins.input") as mocked_input:
+        await cli.cli(["enumerate", "--local", str(repo)])
+    mocked_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cli_local_mutex_with_target(tmp_path: Path, capfd):
+    repo = tmp_path / "demo"
+    repo.mkdir()
+    _write_git_origin(repo, "owner/demo")
+    _write_workflow(repo, "ci.yml", PWN_WORKFLOW)
+    _scrub_gh_token()
+
+    with pytest.raises(SystemExit):
+        await cli.cli(["enumerate", "--local", str(repo), "--target", "exampleorg"])
+    _, err = capfd.readouterr()
+    assert "--local cannot be combined with" in err
+
+
+@pytest.mark.asyncio
+async def test_cli_local_mutex_with_repository(tmp_path: Path, capfd):
+    repo = tmp_path / "demo"
+    repo.mkdir()
+    _write_git_origin(repo, "owner/demo")
+    _write_workflow(repo, "ci.yml", PWN_WORKFLOW)
+    _scrub_gh_token()
+
+    with pytest.raises(SystemExit):
+        await cli.cli(
+            [
+                "enumerate",
+                "--local",
+                str(repo),
+                "--repository",
+                "owner/demo",
+            ]
+        )
+    _, err = capfd.readouterr()
+    assert "--local cannot be combined with" in err
+
+
+@pytest.mark.asyncio
+async def test_cli_local_path_does_not_exist(tmp_path: Path, capfd):
+    _scrub_gh_token()
+    missing = tmp_path / "nope"
+    with pytest.raises(SystemExit):
+        await cli.cli(["enumerate", "--local", str(missing)])
+    _, err = capfd.readouterr()
+    assert "does not exist" in err


### PR DESCRIPTION
## Summary
Closes #256.

Adds `gatox enumerate --local PATH` for fully offline scanning of locally-cloned repositories. No GitHub API calls, no `GH_TOKEN` required.

### UX
- `--local PATH` — auto-detects single repo (PATH has `.github/workflows/`) vs. multi-repo directory. `--local-recursive` walks deeper.
- Repo identity is parsed from `.git/config` origin (https / ssh / git@ / trailing-slash variants supported); missing or non-GitHub origin falls back to a synthetic `local::<dirname>` so naked workflow files still scan.
- Mutually exclusive with `--target / -r / -R / --self-enumeration / --validate / --commit`.
- `GH_TOKEN` is no longer required when `--local` is the sole target.

### What's stitched offline
- `workflow_run` triggers across repos that are both in the scan set.
- `workflow_call` reusable-workflow references across repos in the scan set.
- Composite actions (`uses: owner/repo/.github/actions/X@ref`) resolved from disk when the action repo is in the scan set; absolute paths and `..` traversal are rejected.

### What's skipped (with debug logs)
Every API-dependent check that can't run offline emits a `[local] skipping <kind>: <detail>` debug log. Categories:
- `external_action_resolution` — third-party actions referenced by `uses:` whose repo isn't in the scan set
- `callee_workflow_resolution` — reusable workflows whose source repo isn't in the scan set
- `run-log analysis` — always offline-skipped (no past runs to inspect)

A final banner summarises: `[local mode] N repos scanned offline; M API-dependent checks skipped (see debug log).`

### Implementation notes
- All new code lives in `gatox/enumerate/local_enumerate.py` (`LocalApiStub`, `parse_origin_url`, `repo_identity`, `discover_repos`, `LocalEnumerator`). The existing `CacheManager` / `workflow_graph` / visitor pipeline is reused unchanged — local mode just populates the cache from disk instead of from the API.
- The CLI plumbing is in `gatox/cli/enumeration/config.py` and `gatox/cli/cli.py`.

## Test plan
- [x] 27 new unit tests in `unit_test/test_local_enumerate.py`
- [x] Full suite: 529 → 556 passing (+27), no regressions
- [x] `ruff check`, `black .`, `isort` all clean
- [x] Real-world: 21 `gatoxtest` repos cloned to a flat directory, scanned offline. Banner: `18 repos scanned offline; 2 API-dependent checks skipped`. The 2 skips are the always-skipped `run-log analysis` and one genuinely out-of-scan-set cross-org reusable workflow (`dotnet/arcade`).
- [x] Diffed local-mode vs `gatox enumerate -t gatoxtest` (API mode). 19 findings each. All shared repo / report-type / trigger tuples match. The single difference: local mode caught an `issue_comment` injection in `gatoxtest/opencode-test/review.yml` on the `dev` default branch that the API enumeration didn't visit.