### PR TITLE
feat(enumerate): richer JSON output + skip flags for secrets and admin runners

### DIFF
--- a/gatox/cli/cli.py
+++ b/gatox/cli/cli.py
@@ -388,6 +388,8 @@ async def enumerate_finegrained(args, parser):
         socks_proxy=args.socks_proxy,
         http_proxy=args.http_proxy,
         skip_log=args.skip_runners,
+        skip_secrets=args.skip_secrets,
+        skip_admin_runners=args.skip_admin_runners,
         github_url=args.api_url,
         ignore_workflow_run=args.ignore_workflow_run,
     )
@@ -429,6 +431,8 @@ async def enumerate_classic(args, parser):
         socks_proxy=args.socks_proxy,
         http_proxy=args.http_proxy,
         skip_log=args.skip_runners,
+        skip_secrets=args.skip_secrets,
+        skip_admin_runners=args.skip_admin_runners,
         github_url=args.api_url,
         ignore_workflow_run=args.ignore_workflow_run,
     )
@@ -654,6 +658,8 @@ async def app(args, parser):
         socks_proxy=args.socks_proxy,
         http_proxy=args.http_proxy,
         skip_log=args.skip_runners,
+        skip_secrets=args.skip_secrets,
+        skip_admin_runners=args.skip_admin_runners,
         github_url=args.api_url,
     )
 

--- a/gatox/cli/enumeration/config.py
+++ b/gatox/cli/enumeration/config.py
@@ -154,3 +154,17 @@ def configure_parser_enumerate(parser):
         action="store_true",
         default=False,
     )
+
+    parser.add_argument(
+        "--skip-secrets",
+        "-ss",
+        action="store_true",
+        help="Skip secrets enumeration for repositories and organizations.",
+    )
+
+    parser.add_argument(
+        "--skip-admin-runners",
+        "-sar",
+        action="store_true",
+        help="Skip admin-level self-hosted runner enumeration via the API.",
+    )

--- a/gatox/enumerate/app_enumerate.py
+++ b/gatox/enumerate/app_enumerate.py
@@ -22,6 +22,8 @@ class AppEnumerator:
         http_proxy: str | None = None,
         github_url: str = "https://api.github.com",
         skip_log: bool = True,
+        skip_secrets: bool = False,
+        skip_admin_runners: bool = False,
         ignore_workflow_run: bool = False,
     ):
         """Initialize App Enumerator.
@@ -33,6 +35,8 @@ class AppEnumerator:
             http_proxy: HTTP proxy configuration
             github_url: GitHub API URL
             skip_log: Skip runner log analysis
+            skip_secrets: Skip secrets enumeration
+            skip_admin_runners: Skip admin-level runner enumeration via the API
             ignore_workflow_run: Ignore workflow_run triggers
         """
         self.app_id = app_id
@@ -41,6 +45,8 @@ class AppEnumerator:
         self.http_proxy = http_proxy
         self.github_url = github_url
         self.skip_log = skip_log
+        self.skip_secrets = skip_secrets
+        self.skip_admin_runners = skip_admin_runners
         self.ignore_workflow_run = ignore_workflow_run
 
         # Initialize App authentication
@@ -182,6 +188,8 @@ class AppEnumerator:
             socks_proxy=self.socks_proxy,
             http_proxy=self.http_proxy,
             skip_log=self.skip_log,
+            skip_secrets=self.skip_secrets,
+            skip_admin_runners=self.skip_admin_runners,
             github_url=self.github_url,
             ignore_workflow_run=self.ignore_workflow_run,
             finegrained_permisions=(

--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -39,6 +39,8 @@ class Enumerator:
         socks_proxy: str | None = None,
         http_proxy: str | None = None,
         skip_log: bool = False,
+        skip_secrets: bool = False,
+        skip_admin_runners: bool = False,
         github_url: str | None = None,
         output_json: str | None = None,
         ignore_workflow_run: bool = False,
@@ -55,6 +57,10 @@ class Enumerator:
             Defaults to None.
             skip_log (bool, optional): If set, then run logs will not be
             downloaded.
+            skip_secrets (bool, optional): If set, then secrets enumeration
+            will be skipped.
+            skip_admin_runners (bool, optional): If set, then admin-level
+            runner enumeration via the API will be skipped.
             output_json (str, optional): JSON file to output enumeration
             results.
             ignore_workflow_run (bool, optional): If set, then
@@ -79,13 +85,15 @@ class Enumerator:
         self.socks_proxy = socks_proxy
         self.http_proxy = http_proxy
         self.skip_log = skip_log
+        self.skip_secrets = skip_secrets
+        self.skip_admin_runners = skip_admin_runners
         self.user_perms = None
         self.github_url = github_url
         self.output_json = output_json
         self.ignore_workflow_run = ignore_workflow_run
         self.finegrained_permissions = finegrained_permisions
 
-        self.repo_e = RepositoryEnum(self.api, skip_log)
+        self.repo_e = RepositoryEnum(self.api, skip_log, skip_secrets)
         self.org_e = OrganizationEnum(self.api)
 
     async def __setup_user_info(self):
@@ -432,7 +440,11 @@ class Enumerator:
         Output.result(f"Enumerating the {Output.bright(org)} organization!")
 
         if organization.org_admin_user and organization.org_admin_scopes:
-            await self.org_e.admin_enum(organization)
+            await self.org_e.admin_enum(
+                organization,
+                skip_runners=self.skip_admin_runners,
+                skip_secrets=self.skip_secrets,
+            )
 
         Recommender.print_org_findings(user_perms["scopes"], organization)
 

--- a/gatox/enumerate/finegrained_enumeration.py
+++ b/gatox/enumerate/finegrained_enumeration.py
@@ -17,6 +17,8 @@ class FineGrainedEnumerator(Enumerator):
         socks_proxy: str | None = None,
         http_proxy: str | None = None,
         skip_log: bool = False,
+        skip_secrets: bool = False,
+        skip_admin_runners: bool = False,
         github_url: str | None = None,
         output_json: str | None = None,
         ignore_workflow_run: bool = False,
@@ -33,6 +35,10 @@ class FineGrainedEnumerator(Enumerator):
             socks_proxy (str, optional): Proxy settings for SOCKS proxy.
             http_proxy (str, optional): Proxy settings for HTTP proxy.
             skip_log (bool, optional): If set, then run logs will not be downloaded.
+            skip_secrets (bool, optional): If set, then secrets enumeration
+            will be skipped.
+            skip_admin_runners (bool, optional): If set, then admin-level
+            runner enumeration via the API will be skipped.
             github_url (str, optional): GitHub API URL.
             output_json (str, optional): JSON file to output enumeration results.
             ignore_workflow_run (bool, optional): If set, then "workflow_run" triggers will be ignored.
@@ -45,6 +51,8 @@ class FineGrainedEnumerator(Enumerator):
             socks_proxy=socks_proxy,
             http_proxy=http_proxy,
             skip_log=skip_log,
+            skip_secrets=skip_secrets,
+            skip_admin_runners=skip_admin_runners,
             github_url=github_url,
             output_json=output_json,
             ignore_workflow_run=ignore_workflow_run,

--- a/gatox/enumerate/ingest/ingest.py
+++ b/gatox/enumerate/ingest/ingest.py
@@ -254,6 +254,8 @@ class DataIngestor:
             repo_wrapper = Repository(repo_data)
             cache.set_repository(repo_wrapper)
 
+            workflow_count = 0
+
             if result["object"]:
                 for yml_node in result["object"]["entries"]:
                     yml_name = yml_node["name"]
@@ -271,6 +273,9 @@ class DataIngestor:
                                 continue
 
                             cache.set_workflow(owner, yml_name, wf_wrapper)
+                            workflow_count += 1
                             await WorkflowGraphBuilder().build_graph_from_yaml(
                                 wf_wrapper, repo_wrapper
                             )
+
+            repo_wrapper.workflow_count = workflow_count

--- a/gatox/enumerate/organization.py
+++ b/gatox/enumerate/organization.py
@@ -69,29 +69,36 @@ class OrganizationEnum:
         else:
             return org_public_repos
 
-    async def admin_enum(self, organization: Organization):
+    async def admin_enum(
+        self,
+        organization: Organization,
+        skip_runners: bool = False,
+        skip_secrets: bool = False,
+    ):
         """Enumeration tasks to perform if the user is an org admin and the
         token has the necessary scopes.
         """
         if organization.org_admin_scopes and organization.org_admin_user:
-            runners = await self.api.org.check_org_runners(organization.name)
-            if runners:
-                org_runners = [
-                    Runner(
-                        runner["name"],
-                        machine_name=None,
-                        os=runner["os"],
-                        status=runner["status"],
-                        labels=runner["labels"],
-                    )
-                    for runner in runners["runners"]
-                ]
-                organization.set_runners(org_runners)
+            if not skip_runners:
+                runners = await self.api.org.check_org_runners(organization.name)
+                if runners:
+                    org_runners = [
+                        Runner(
+                            runner["name"],
+                            machine_name=None,
+                            os=runner["os"],
+                            status=runner["status"],
+                            labels=runner["labels"],
+                        )
+                        for runner in runners["runners"]
+                    ]
+                    organization.set_runners(org_runners)
 
-            org_secrets = await self.api.org.get_org_secrets(organization.name)
-            if org_secrets:
-                org_secrets = [
-                    Secret(secret, organization.name) for secret in org_secrets
-                ]
+            if not skip_secrets:
+                org_secrets = await self.api.org.get_org_secrets(organization.name)
+                if org_secrets:
+                    org_secrets = [
+                        Secret(secret, organization.name) for secret in org_secrets
+                    ]
 
-                organization.set_secrets(org_secrets)
+                    organization.set_secrets(org_secrets)

--- a/gatox/enumerate/repository.py
+++ b/gatox/enumerate/repository.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class RepositoryEnum:
     """Repository specific enumeration functionality."""
 
-    def __init__(self, api: Api, skip_log: bool):
+    def __init__(self, api: Api, skip_log: bool, skip_secrets: bool = False):
         """Initialize enumeration class with instantiated API wrapper and CLI
         parameters.
 
@@ -23,6 +23,7 @@ class RepositoryEnum:
         """
         self.api = api
         self.skip_log = skip_log
+        self.skip_secrets = skip_secrets
 
     async def perform_runlog_enumeration(
         self, repository: Repository, workflows: set | list
@@ -119,6 +120,9 @@ class RepositoryEnum:
             repository (Repository): Wrapper object created from calling the
             API and retrieving a repository.
         """
+        if self.skip_secrets:
+            return
+
         if repository.can_push():
             secrets = await self.api.repo.get_secrets(repository.name)
             wrapped_env_secrets = []

--- a/gatox/models/repository.py
+++ b/gatox/models/repository.py
@@ -34,6 +34,7 @@ class Repository:
         self.accessible_runners: list[Runner] = []
         self.runners: list[Runner] = []
         self.risks = {}
+        self.workflow_count = 0
 
     def is_admin(self):
         return self.permission_data.get("admin", False)
@@ -126,6 +127,9 @@ class Repository:
         representation = {
             "name": self.name,
             "enum_time": self.enum_time.ctime(),
+            "description": self.repo_data.get("description", ""),
+            "pushed_at": self.repo_data.get("pushed_at", ""),
+            "workflow_count": self.workflow_count,
             "permissions": self.permission_data,
             "can_fork": self.can_fork(),
             "stars": self.repo_data["stargazers_count"],

--- a/unit_test/test_cli.py
+++ b/unit_test/test_cli.py
@@ -154,6 +154,8 @@ async def test_cli_old_token(mock_enumerator, capfd):
         socks_proxy=None,
         http_proxy=None,
         skip_log=False,
+        skip_secrets=False,
+        skip_admin_runners=False,
         github_url=None,
         ignore_workflow_run=False,
     )

--- a/unit_test/test_cli.py
+++ b/unit_test/test_cli.py
@@ -686,3 +686,195 @@ async def test_payload_only_with_valid_target_params(mock_payload):
         ]
     )
     mock_payload.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CLI flag parsing — --skip-secrets / --skip-admin-runners
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("gatox.cli.cli.Enumerator")
+async def test_cli_skip_secrets_long_flag(mock_enumerator):
+    """--skip-secrets should be parsed and forwarded to the Enumerator."""
+    os.environ["GH_TOKEN"] = "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    mock_instance = mock_enumerator.return_value
+    mock_instance.api = mock.MagicMock()
+    mock_instance.api.user.check_user = AsyncMock(
+        return_value={
+            "user": "testUser",
+            "scopes": ["repo", "workflow"],
+        }
+    )
+    mock_instance.api.user.get_user_type = AsyncMock(return_value="Organization")
+    mock_instance.enumerate_organization = AsyncMock(return_value={"testOrg": "data"})
+    mock_instance.user_perms = {"user": "testUser", "scopes": ["repo", "workflow"]}
+
+    await cli.cli(["enumerate", "-t", "test", "--skip-secrets"])
+
+    mock_enumerator.assert_called_once_with(
+        "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy=None,
+        skip_log=False,
+        skip_secrets=True,
+        skip_admin_runners=False,
+        github_url=None,
+        ignore_workflow_run=False,
+    )
+
+
+@mock.patch("gatox.cli.cli.Enumerator")
+async def test_cli_skip_secrets_short_flag(mock_enumerator):
+    """-ss should be parsed and forwarded to the Enumerator."""
+    os.environ["GH_TOKEN"] = "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    mock_instance = mock_enumerator.return_value
+    mock_instance.api = mock.MagicMock()
+    mock_instance.api.user.check_user = AsyncMock(
+        return_value={
+            "user": "testUser",
+            "scopes": ["repo", "workflow"],
+        }
+    )
+    mock_instance.api.user.get_user_type = AsyncMock(return_value="Organization")
+    mock_instance.enumerate_organization = AsyncMock(return_value={"testOrg": "data"})
+    mock_instance.user_perms = {"user": "testUser", "scopes": ["repo", "workflow"]}
+
+    await cli.cli(["enumerate", "-t", "test", "-ss"])
+
+    mock_enumerator.assert_called_once_with(
+        "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy=None,
+        skip_log=False,
+        skip_secrets=True,
+        skip_admin_runners=False,
+        github_url=None,
+        ignore_workflow_run=False,
+    )
+
+
+@mock.patch("gatox.cli.cli.Enumerator")
+async def test_cli_skip_admin_runners_long_flag(mock_enumerator):
+    """--skip-admin-runners should be parsed and forwarded to the Enumerator."""
+    os.environ["GH_TOKEN"] = "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    mock_instance = mock_enumerator.return_value
+    mock_instance.api = mock.MagicMock()
+    mock_instance.api.user.check_user = AsyncMock(
+        return_value={
+            "user": "testUser",
+            "scopes": ["repo", "workflow"],
+        }
+    )
+    mock_instance.api.user.get_user_type = AsyncMock(return_value="Organization")
+    mock_instance.enumerate_organization = AsyncMock(return_value={"testOrg": "data"})
+    mock_instance.user_perms = {"user": "testUser", "scopes": ["repo", "workflow"]}
+
+    await cli.cli(["enumerate", "-t", "test", "--skip-admin-runners"])
+
+    mock_enumerator.assert_called_once_with(
+        "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy=None,
+        skip_log=False,
+        skip_secrets=False,
+        skip_admin_runners=True,
+        github_url=None,
+        ignore_workflow_run=False,
+    )
+
+
+@mock.patch("gatox.cli.cli.Enumerator")
+async def test_cli_skip_admin_runners_short_flag(mock_enumerator):
+    """-sar should be parsed and forwarded to the Enumerator."""
+    os.environ["GH_TOKEN"] = "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    mock_instance = mock_enumerator.return_value
+    mock_instance.api = mock.MagicMock()
+    mock_instance.api.user.check_user = AsyncMock(
+        return_value={
+            "user": "testUser",
+            "scopes": ["repo", "workflow"],
+        }
+    )
+    mock_instance.api.user.get_user_type = AsyncMock(return_value="Organization")
+    mock_instance.enumerate_organization = AsyncMock(return_value={"testOrg": "data"})
+    mock_instance.user_perms = {"user": "testUser", "scopes": ["repo", "workflow"]}
+
+    await cli.cli(["enumerate", "-t", "test", "-sar"])
+
+    mock_enumerator.assert_called_once_with(
+        "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy=None,
+        skip_log=False,
+        skip_secrets=False,
+        skip_admin_runners=True,
+        github_url=None,
+        ignore_workflow_run=False,
+    )
+
+
+@mock.patch("gatox.cli.cli.Enumerator")
+async def test_cli_defaults_skip_flags_to_false(mock_enumerator):
+    """When neither --skip-secrets nor --skip-admin-runners is given, both
+    should default to False."""
+    os.environ["GH_TOKEN"] = "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    mock_instance = mock_enumerator.return_value
+    mock_instance.api = mock.MagicMock()
+    mock_instance.api.user.check_user = AsyncMock(
+        return_value={
+            "user": "testUser",
+            "scopes": ["repo", "workflow"],
+        }
+    )
+    mock_instance.api.user.get_user_type = AsyncMock(return_value="Organization")
+    mock_instance.enumerate_organization = AsyncMock(return_value={"testOrg": "data"})
+    mock_instance.user_perms = {"user": "testUser", "scopes": ["repo", "workflow"]}
+
+    await cli.cli(["enumerate", "-t", "test"])
+
+    mock_enumerator.assert_called_once_with(
+        "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy=None,
+        skip_log=False,
+        skip_secrets=False,
+        skip_admin_runners=False,
+        github_url=None,
+        ignore_workflow_run=False,
+    )
+
+
+@mock.patch("gatox.cli.cli.Enumerator")
+async def test_cli_both_skip_flags_together(mock_enumerator):
+    """Both --skip-secrets and --skip-admin-runners can be used together."""
+    os.environ["GH_TOKEN"] = "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    mock_instance = mock_enumerator.return_value
+    mock_instance.api = mock.MagicMock()
+    mock_instance.api.user.check_user = AsyncMock(
+        return_value={
+            "user": "testUser",
+            "scopes": ["repo", "workflow"],
+        }
+    )
+    mock_instance.api.user.get_user_type = AsyncMock(return_value="Organization")
+    mock_instance.enumerate_organization = AsyncMock(return_value={"testOrg": "data"})
+    mock_instance.user_perms = {"user": "testUser", "scopes": ["repo", "workflow"]}
+
+    await cli.cli(["enumerate", "-t", "test", "--skip-secrets", "--skip-admin-runners"])
+
+    mock_enumerator.assert_called_once_with(
+        "gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        socks_proxy=None,
+        http_proxy=None,
+        skip_log=False,
+        skip_secrets=True,
+        skip_admin_runners=True,
+        github_url=None,
+        ignore_workflow_run=False,
+    )

--- a/unit_test/test_enumerate.py
+++ b/unit_test/test_enumerate.py
@@ -614,3 +614,183 @@ async def test_validate_only_with_public_repo_scope(mock_api, capfd):
     out, _ = capfd.readouterr()
     # Should not contain the warning about insufficient access
     assert "Token does not have sufficient access to list orgs!" not in out
+
+
+# ---------------------------------------------------------------------------
+# DataIngestor.construct_workflow_cache — workflow_count
+# ---------------------------------------------------------------------------
+
+
+@patch("gatox.enumerate.ingest.ingest.WorkflowGraphBuilder")
+@patch("gatox.enumerate.ingest.ingest.CacheManager")
+async def test_construct_workflow_cache_sets_workflow_count(
+    mock_cache_mgr_cls, mock_graph_builder_cls
+):
+    """construct_workflow_cache should count the valid workflow YAML entries
+    and set repo_wrapper.workflow_count accordingly."""
+    from gatox.enumerate.ingest.ingest import DataIngestor
+
+    # Set up the mock cache instance
+    mock_cache = AsyncMock()
+    mock_cache_mgr_cls.return_value = mock_cache
+
+    # Mock graph builder
+    mock_builder = AsyncMock()
+    mock_graph_builder_cls.return_value = mock_builder
+
+    # Build a GQL result with 2 workflow YAML entries
+    gql_result = [
+        {
+            "nameWithOwner": "testOrg/testRepo",
+            "url": "https://github.com/testOrg/testRepo",
+            "isPrivate": False,
+            "isFork": False,
+            "isArchived": False,
+            "forkingAllowed": True,
+            "pushedAt": "2023-01-01T00:00:00Z",
+            "defaultBranchRef": {"name": "main"},
+            "viewerPermission": "WRITE",
+            "stargazers": {"totalCount": 10},
+            "object": {
+                "entries": [
+                    {
+                        "name": "ci.yml",
+                        "type": "blob",
+                        "object": {
+                            "text": "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+                        },
+                    },
+                    {
+                        "name": "deploy.yml",
+                        "type": "blob",
+                        "object": {
+                            "text": "name: Deploy\non: push\njobs:\n  deploy:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo deploy\n",
+                        },
+                    },
+                ]
+            },
+        }
+    ]
+
+    await DataIngestor.construct_workflow_cache(gql_result)
+
+    # Cache should have set the repository
+    mock_cache.set_repository.assert_called_once()
+    repo_wrapper = mock_cache.set_repository.call_args[0][0]
+
+    # Workflow count should be 2 (both YAML entries were valid)
+    assert repo_wrapper.workflow_count == 2
+
+
+@patch("gatox.enumerate.ingest.ingest.WorkflowGraphBuilder")
+@patch("gatox.enumerate.ingest.ingest.CacheManager")
+async def test_construct_workflow_cache_counts_only_valid_ymls(
+    mock_cache_mgr_cls, mock_graph_builder_cls
+):
+    """Workflows that are invalid (e.g. dependabot configs) should not be
+    counted in workflow_count."""
+    from gatox.enumerate.ingest.ingest import DataIngestor
+
+    mock_cache = AsyncMock()
+    mock_cache_mgr_cls.return_value = mock_cache
+
+    mock_builder = AsyncMock()
+    mock_graph_builder_cls.return_value = mock_builder
+
+    # 3 entries: 2 valid YAML, 1 dependabot (invalid), 1 non-yaml (skipped)
+    gql_result = [
+        {
+            "nameWithOwner": "testOrg/testRepo",
+            "url": "https://github.com/testOrg/testRepo",
+            "isPrivate": False,
+            "isFork": False,
+            "isArchived": False,
+            "forkingAllowed": True,
+            "pushedAt": "2023-01-01T00:00:00Z",
+            "defaultBranchRef": {"name": "main"},
+            "viewerPermission": "WRITE",
+            "stargazers": {"totalCount": 10},
+            "object": {
+                "entries": [
+                    {
+                        "name": "ci.yml",
+                        "type": "blob",
+                        "object": {
+                            "text": "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+                        },
+                    },
+                    {
+                        "name": "dependabot.yml",
+                        "type": "blob",
+                        "object": {
+                            "text": "version: 2\nupdates:\n  - package-ecosystem: npm\n    directory: /\n    schedule:\n      interval: weekly\n",
+                        },
+                    },
+                    {
+                        "name": "README.md",
+                        "type": "blob",
+                        "object": {"text": "# README\n"},
+                    },
+                ]
+            },
+        }
+    ]
+
+    await DataIngestor.construct_workflow_cache(gql_result)
+
+    repo_wrapper = mock_cache.set_repository.call_args[0][0]
+    # Only ci.yml is a valid workflow YAML
+    # dependabot.yml gets marked invalid, README.md is not .yml/.yaml
+    assert repo_wrapper.workflow_count == 1
+
+
+@patch("gatox.enumerate.ingest.ingest.WorkflowGraphBuilder")
+@patch("gatox.enumerate.ingest.ingest.CacheManager")
+async def test_construct_workflow_cache_zero_workflows(
+    mock_cache_mgr_cls, mock_graph_builder_cls
+):
+    """workflow_count should be 0 when there are no workflow YAML files."""
+    from gatox.enumerate.ingest.ingest import DataIngestor
+
+    mock_cache = AsyncMock()
+    mock_cache_mgr_cls.return_value = mock_cache
+
+    mock_builder = AsyncMock()
+    mock_graph_builder_cls.return_value = mock_builder
+
+    gql_result = [
+        {
+            "nameWithOwner": "testOrg/emptyRepo",
+            "url": "https://github.com/testOrg/emptyRepo",
+            "isPrivate": False,
+            "isFork": False,
+            "isArchived": False,
+            "forkingAllowed": True,
+            "pushedAt": "2023-01-01T00:00:00Z",
+            "defaultBranchRef": {"name": "main"},
+            "viewerPermission": "READ",
+            "stargazers": {"totalCount": 0},
+            "object": {"entries": []},
+        }
+    ]
+
+    await DataIngestor.construct_workflow_cache(gql_result)
+
+    repo_wrapper = mock_cache.set_repository.call_args[0][0]
+    assert repo_wrapper.workflow_count == 0
+
+
+@patch("gatox.enumerate.ingest.ingest.CacheManager")
+async def test_construct_workflow_cache_handles_none(mock_cache_mgr_cls):
+    """construct_workflow_cache should return early when yml_results is None."""
+    from gatox.enumerate.ingest.ingest import DataIngestor
+
+    mock_cache = AsyncMock()
+    mock_cache_mgr_cls.return_value = mock_cache
+
+    # Should not raise
+    await DataIngestor.construct_workflow_cache(None)
+
+    # Cache should never be touched
+    mock_cache.set_repository.assert_not_called()
+    mock_cache.set_workflow.assert_not_called()

--- a/unit_test/test_org_enumerate.py
+++ b/unit_test/test_org_enumerate.py
@@ -109,3 +109,105 @@ async def test_admin_enum():
 
     assert len(organization.secrets) == 2
     assert len(organization.runners) == 1
+
+
+# ---------------------------------------------------------------------------
+# OrganizationEnum.admin_enum — skip flags
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_enum_skip_runners():
+    """When skip_runners=True, runner enumeration is skipped but secrets
+    are still enumerated."""
+    mock_api = AsyncMock()
+
+    organization = Organization(
+        TEST_ORG_DATA, user_scopes=["repo", "workflow", "admin:org"]
+    )
+
+    mock_api.org.get_org_secrets.return_value = [
+        {
+            "name": "DEPLOY_TOKEN",
+            "created_at": "2019-08-10T14:59:22Z",
+            "updated_at": "2020-01-10T14:59:22Z",
+            "visibility": "all",
+        },
+    ]
+
+    gh_enumeration_runner = OrganizationEnum(mock_api)
+
+    await gh_enumeration_runner.admin_enum(
+        organization, skip_runners=True, skip_secrets=False
+    )
+
+    # Runners should NOT have been queried
+    mock_api.org.check_org_runners.assert_not_called()
+    assert len(organization.runners) == 0
+
+    # Secrets SHOULD have been queried
+    mock_api.org.get_org_secrets.assert_called_once_with(organization.name)
+    assert len(organization.secrets) == 1
+
+
+async def test_admin_enum_skip_secrets():
+    """When skip_secrets=True, secrets enumeration is skipped but runners
+    are still enumerated."""
+    mock_api = AsyncMock()
+
+    organization = Organization(
+        TEST_ORG_DATA, user_scopes=["repo", "workflow", "admin:org"]
+    )
+
+    mock_api.org.check_org_runners.return_value = {
+        "total_count": 1,
+        "runners": [
+            {
+                "id": 21,
+                "name": "ghrunner-test",
+                "os": "Linux",
+                "status": "online",
+                "busy": False,
+                "labels": [
+                    {"id": 1, "name": "self-hosted", "type": "read-only"},
+                    {"id": 2, "name": "Linux", "type": "read-only"},
+                    {"id": 3, "name": "X64", "type": "read-only"},
+                ],
+            }
+        ],
+    }
+
+    gh_enumeration_runner = OrganizationEnum(mock_api)
+
+    await gh_enumeration_runner.admin_enum(
+        organization, skip_runners=False, skip_secrets=True
+    )
+
+    # Runners SHOULD have been queried
+    mock_api.org.check_org_runners.assert_called_once_with(organization.name)
+    assert len(organization.runners) == 1
+
+    # Secrets should NOT have been queried
+    mock_api.org.get_org_secrets.assert_not_called()
+    assert len(organization.secrets) == 0
+
+
+async def test_admin_enum_skip_both():
+    """When both skip_runners=True and skip_secrets=True, neither runners
+    nor secrets are enumerated."""
+    mock_api = AsyncMock()
+
+    organization = Organization(
+        TEST_ORG_DATA, user_scopes=["repo", "workflow", "admin:org"]
+    )
+
+    gh_enumeration_runner = OrganizationEnum(mock_api)
+
+    await gh_enumeration_runner.admin_enum(
+        organization, skip_runners=True, skip_secrets=True
+    )
+
+    # Neither API should be called
+    mock_api.org.check_org_runners.assert_not_called()
+    mock_api.org.get_org_secrets.assert_not_called()
+    assert len(organization.runners) == 0
+    assert len(organization.secrets) == 0

--- a/unit_test/test_repo_enumerate.py
+++ b/unit_test/test_repo_enumerate.py
@@ -135,3 +135,149 @@ async def test_enumerate_repo_secrets():
     await gh_enumeration_runner.enumerate_repository_secrets(test_repo)
 
     assert len(test_repo.secrets) > 0
+
+
+# ---------------------------------------------------------------------------
+# Repository.toJSON() — new fields
+# ---------------------------------------------------------------------------
+
+
+def test_toJSON_includes_description():
+    """Repository.toJSON() should emit the 'description' field from repo_data."""
+    repo_data = json.loads(json.dumps(TEST_REPO_DATA))
+    repo_data["description"] = "This your first repo!"
+    repo = Repository(repo_data)
+    result = repo.toJSON()
+
+    assert result["description"] == "This your first repo!"
+
+
+def test_toJSON_includes_pushed_at():
+    """Repository.toJSON() should emit the 'pushed_at' field from repo_data."""
+    repo_data = json.loads(json.dumps(TEST_REPO_DATA))
+    repo_data["pushed_at"] = "2011-01-26T19:06:43Z"
+    repo = Repository(repo_data)
+    result = repo.toJSON()
+
+    assert result["pushed_at"] == "2011-01-26T19:06:43Z"
+
+
+def test_toJSON_includes_workflow_count():
+    """Repository.toJSON() should emit the 'workflow_count' attribute."""
+    repo_data = json.loads(json.dumps(TEST_REPO_DATA))
+    repo = Repository(repo_data)
+    repo.workflow_count = 5
+    result = repo.toJSON()
+
+    assert result["workflow_count"] == 5
+
+
+def test_toJSON_workflow_count_defaults_to_zero():
+    """workflow_count defaults to 0 when not explicitly set."""
+    repo_data = json.loads(json.dumps(TEST_REPO_DATA))
+    repo = Repository(repo_data)
+    result = repo.toJSON()
+
+    assert result["workflow_count"] == 0
+
+
+def test_toJSON_description_defaults_to_empty_string():
+    """description defaults to '' when repo_data has no 'description' key."""
+    repo_data = {
+        "full_name": "testOrg/testRepo",
+        "html_url": "https://github.com/testOrg/testRepo",
+        "visibility": "public",
+        "default_branch": "main",
+        "fork": False,
+        "stargazers_count": 0,
+        "permissions": {"pull": True, "push": False, "admin": False},
+        "archived": False,
+        "isFork": False,
+        "environments": [],
+    }
+    repo = Repository(repo_data)
+    result = repo.toJSON()
+
+    assert result["description"] == ""
+
+
+def test_toJSON_pushed_at_defaults_to_empty_string():
+    """pushed_at defaults to '' when repo_data has no 'pushed_at' key."""
+    repo_data = {
+        "full_name": "testOrg/testRepo",
+        "html_url": "https://github.com/testOrg/testRepo",
+        "visibility": "public",
+        "default_branch": "main",
+        "fork": False,
+        "stargazers_count": 0,
+        "permissions": {"pull": True, "push": False, "admin": False},
+        "archived": False,
+        "isFork": False,
+        "environments": [],
+    }
+    repo = Repository(repo_data)
+    result = repo.toJSON()
+
+    assert result["pushed_at"] == ""
+
+
+def test_toJSON_all_new_fields_present():
+    """Verify that all new fields appear in the toJSON() dictionary keys."""
+    repo_data = json.loads(json.dumps(TEST_REPO_DATA))
+    repo = Repository(repo_data)
+    result = repo.toJSON()
+
+    assert "description" in result
+    assert "pushed_at" in result
+    assert "workflow_count" in result
+
+
+# ---------------------------------------------------------------------------
+# RepositoryEnum.enumerate_repository_secrets — skip_secrets flag
+# ---------------------------------------------------------------------------
+
+
+async def test_skip_secrets_skips_api_calls():
+    """When skip_secrets=True, enumerate_repository_secrets returns immediately
+    without making any API calls."""
+    mock_api = AsyncMock()
+    gh_enumeration_runner = RepositoryEnum(mock_api, False, skip_secrets=True)
+
+    repo_data = json.loads(json.dumps(TEST_REPO_DATA))
+    test_repo = Repository(repo_data)
+
+    await gh_enumeration_runner.enumerate_repository_secrets(test_repo)
+
+    # API should never be called
+    mock_api.repo.get_secrets.assert_not_called()
+    mock_api.repo.get_environment_secrets.assert_not_called()
+    mock_api.repo.get_repo_org_secrets.assert_not_called()
+    # Secrets list should still be empty (default)
+    assert len(test_repo.secrets) == 0
+
+
+async def test_skip_secrets_false_enumerates_normally():
+    """When skip_secrets=False (default), secrets are enumerated as expected."""
+    mock_api = AsyncMock()
+
+    mock_api.repo.get_secrets.return_value = [
+        {
+            "name": "GIST_ID",
+            "created_at": "2019-08-10T14:59:22Z",
+            "updated_at": "2020-01-10T14:59:22Z",
+            "visibility": "private",
+        },
+    ]
+    mock_api.repo.get_repo_org_secrets.return_value = []
+
+    gh_enumeration_runner = RepositoryEnum(mock_api, False, skip_secrets=False)
+
+    repo_data = json.loads(json.dumps(TEST_REPO_DATA))
+    test_repo = Repository(repo_data)
+
+    await gh_enumeration_runner.enumerate_repository_secrets(test_repo)
+
+    # API should have been called
+    mock_api.repo.get_secrets.assert_called_once_with(test_repo.name)
+    assert len(test_repo.secrets) == 1
+    assert test_repo.secrets[0].name == "GIST_ID"


### PR DESCRIPTION
## Summary
- Add `description`, `pushed_at`, and `workflow_count` fields to JSON output (`-oJ`)
- Add `--skip-secrets` / `-ss` flag to skip secrets enumeration
- Add `--skip-admin-runners` / `-sar` flag to skip admin-level runner API calls

**Depends on PR #259 (API modular split)** - these changes use the new `self.api.repo.*`, `self.api.action.*`, etc. pattern.

## Details

### JSON output enrichment
- `description`: from REST API (empty for GQL-only repos, intentionally kept out of GQL to minimize fields)
- `pushed_at`: already in `repo_data` from both REST and GQL, just not emitted previously
- `workflow_count`: counted during GQL workflow ingestion

### New CLI flags
- `--skip-secrets` / `-ss`: gates both repo-level and org-level secrets enumeration
- `--skip-admin-runners` / `-sar`: gates admin API runner listing (independent of existing `--skip-runners` which controls run-log analysis)

## Test plan
- [x] 556 unit tests pass
- [x] `ruff check` and `ruff format` pass
- [ ] `gato-x enumerate --target <org> -oJ output.json` includes new fields
- [ ] `--skip-secrets` omits secrets from output
- [ ] `--skip-admin-runners` omits admin runner listing