### PR TITLE
fix(enumerate): reduce GraphQL batch size from 50/100 to 30

### DIFF
--- a/gatox/enumerate/enumerate.py
+++ b/gatox/enumerate/enumerate.py
@@ -143,40 +143,89 @@ class Enumerator:
 
         return True
 
-    async def __query_graphql_workflows(self, queries):
+    async def __query_graphql_workflows(self, queries, repo_groups=None):
         """
         Query workflows using the GitHub GraphQL API.
 
-        This method performs an IO-heavy operation by querying workflows in batches.
-        It utilizes a semaphore to limit concurrent execution to 4 workers.
+        This method performs an IO-heavy operation by querying workflows
+        in batches, with adaptive re-splitting when GitHub returns 502
+        errors (indicating the batch is too large). It utilizes a
+        semaphore to limit concurrent execution to 4 workers.
 
         Args:
-            queries (List[Any]): A list of GraphQL query objects to be executed.
+            queries (list): A list of GraphQL query dicts to execute.
+            repo_groups (list, optional): Parallel list where
+                repo_groups[i] contains the Repository objects or repo
+                slugs that were batched into queries[i]. Required for
+                adaptive re-splitting on 502 errors.
 
         Returns:
             None
-
-        Raises:
-            Exception: Propagates any exceptions raised during the query execution.
         """
+        if repo_groups is None:
+            repo_groups = [None] * len(queries)
+
         Output.info(f"Querying repositories in {len(queries)} batches!")
         semaphore = asyncio.Semaphore(4)
-        tasks = []
 
-        async def bounded_query(query, i):
+        async def bounded_query(query, idx):
             async with semaphore:
-                return await DataIngestor.perform_query(self.api, query, i)
+                result = await DataIngestor.perform_query(self.api, query, idx)
+                return idx, result
 
-        for i, wf_query in enumerate(queries):
-            tasks.append(bounded_query(wf_query, i))
+        tasks = [bounded_query(wf_query, i) for i, wf_query in enumerate(queries)]
+        total_batches = len(queries)
 
         for coro in asyncio.as_completed(tasks):
-            result = await coro
+            i, result = await coro
             Output.info(
-                f"Processed {DataIngestor.check_status()}/{len(queries)} batches.",
+                f"Processed {DataIngestor.check_status()}/{total_batches} batches.",
                 end="\r",
             )
-            await DataIngestor.construct_workflow_cache(result)
+
+            if result["success"]:
+                await DataIngestor.construct_workflow_cache(result["data"])
+            elif result["should_split"] and repo_groups[i] is not None:
+                repos = repo_groups[i]
+                if len(repos) <= 3:
+                    Output.warn(
+                        f"GraphQL batch of {len(repos)} repos failed "
+                        "with 502 but batch is already at minimum "
+                        "size. Falling back to REST for these repos."
+                    )
+                    await DataIngestor.construct_workflow_cache(None)
+                    continue
+
+                mid = len(repos) // 2
+                half1 = repos[:mid]
+                half2 = repos[mid:]
+
+                Output.info(
+                    f"Batch {i} returned 502, splitting "
+                    f"{len(repos)} repos into smaller batches..."
+                )
+
+                # Determine whether repos are Repository objects or
+                # string slugs and call the appropriate query builder.
+                if isinstance(half1[0], Repository):
+                    sub_queries, sub_groups = GqlQueries.get_workflow_ymls(
+                        half1, batch_size=len(half1)
+                    )
+                else:
+                    sub_queries, sub_groups = GqlQueries.get_workflow_ymls_from_list(
+                        half1, batch_size=len(half1)
+                    )
+                await self.__query_graphql_workflows(sub_queries, sub_groups)
+
+                if isinstance(half2[0], Repository):
+                    sub_queries, sub_groups = GqlQueries.get_workflow_ymls(
+                        half2, batch_size=len(half2)
+                    )
+                else:
+                    sub_queries, sub_groups = GqlQueries.get_workflow_ymls_from_list(
+                        half2, batch_size=len(half2)
+                    )
+                await self.__query_graphql_workflows(sub_queries, sub_groups)
 
     async def __retrieve_missing_ymls(self, repo_name: str):
         """ """
@@ -463,8 +512,8 @@ class Enumerator:
         )
 
         Output.info("Querying and caching workflow YAML files!")
-        wf_queries = GqlQueries.get_workflow_ymls(enum_list)
-        await self.__query_graphql_workflows(wf_queries)
+        wf_queries, wf_repo_groups = GqlQueries.get_workflow_ymls(enum_list)
+        await self.__query_graphql_workflows(wf_queries, wf_repo_groups)
         await self.__finalize_caches(enum_list)
 
         await self.process_graph()
@@ -558,8 +607,8 @@ class Enumerator:
             f"Querying and caching workflow YAML files "
             f"from {len(repo_names)} repositories!"
         )
-        queries = GqlQueries.get_workflow_ymls_from_list(repo_names)
-        await self.__query_graphql_workflows(queries)
+        queries, repo_groups = GqlQueries.get_workflow_ymls_from_list(repo_names)
+        await self.__query_graphql_workflows(queries, repo_groups)
         for repo in repo_names:
             await self.__retrieve_missing_ymls(repo)
 

--- a/gatox/enumerate/ingest/ingest.py
+++ b/gatox/enumerate/ingest/ingest.py
@@ -118,7 +118,8 @@ class DataIngestor:
     @classmethod
     async def perform_query(cls, api, work_query, batch):
         """
-        Performs a GraphQL query of repositories with up to 3 attempts, increasing the sleep timer from 4, 8, and then finally 16 seconds.
+        Performs a GraphQL query of repositories with up to 4 attempts,
+        increasing the sleep timer from 4, 8, and then finally 16 seconds.
 
         Args:
             api (object): The API client used to make the POST requests.
@@ -126,11 +127,13 @@ class DataIngestor:
             batch (int): The batch number for which the query is being performed.
 
         Returns:
-            list or dict: The nodes or values from the query result if successful, otherwise None.
-
-        Raises:
-            Exception: If an error occurs during the query execution.
+            dict with keys:
+                "success": bool - True if query returned data.
+                "data": list or None - The nodes/values from the result.
+                "should_split": bool - True if 502/503 errors suggest
+                    batch is too large and should be split.
         """
+        any_gateway_errors = False
         try:
             for _ in range(0, 4):
                 # We lock if another thread is sleeping due to a rate limit
@@ -150,12 +153,17 @@ class DataIngestor:
                     json_res = result.json()["data"]
                     await cls.update_count()
                     if "nodes" in json_res:
-                        return result.json()["data"]["nodes"]
+                        data = result.json()["data"]["nodes"]
                     else:
-                        return result.json()["data"].values()
+                        data = list(result.json()["data"].values())
+                    return {"success": True, "data": data, "should_split": False}
                 elif result.status_code == 403:
                     async with cls.__rl_lock:
                         await asyncio.sleep(15 + random.randint(0, 3))
+                elif result.status_code in (502, 503):
+                    # 502/503 suggest batch is too large
+                    any_gateway_errors = True
+                    await asyncio.sleep(10 + random.randint(0, 3))
                 else:
                     # Add some jitter
                     await asyncio.sleep(10 + random.randint(0, 3))
@@ -163,12 +171,18 @@ class DataIngestor:
             Output.warn(
                 f"GraphQL attempts failed for batch {str(batch)}, will revert to REST for impacted repos."
             )
+            return {
+                "success": False,
+                "data": None,
+                "should_split": any_gateway_errors,
+            }
         except Exception as e:
             Output.warn(
                 "Exception while running GraphQL query, will revert to REST "
                 "API workflow query for impacted repositories!"
             )
             logger.warning(f"{type(e)}: {str(e)}")
+            return {"success": False, "data": None, "should_split": False}
 
     @staticmethod
     async def construct_workflow_cache(yml_results):

--- a/gatox/github/gql_queries.py
+++ b/gatox/github/gql_queries.py
@@ -161,30 +161,34 @@ class GqlQueries:
     """
 
     @staticmethod
-    def get_workflow_ymls_from_list(repos: list):
+    def get_workflow_ymls_from_list(repos: list, batch_size: int = 50):
         """
         Constructs a list of GraphQL queries to fetch workflow YAML
         files from a list of repositories.
 
         This method splits the list of repositories into chunks of
-        up to 100 repositories each, and constructs a separate
+        up to batch_size repositories each, and constructs a separate
         GraphQL query for each chunk. Each query fetches the workflow
         YAML files from the repositories in one chunk.
 
         Args:
             repos (list): A list of repository slugs, where each
             slug is a string in the format "owner/name".
+            batch_size (int, optional): Maximum number of repos per
+            GraphQL query. Defaults to 50.
 
         Returns:
-            list: A list of dictionaries, where each dictionary
-            contains a single GraphQL query in the format:
-            {"query": "<GraphQL query string>"}.
+            tuple: (queries, repo_groups) where:
+                queries (list): List of dicts with "query" key.
+                repo_groups (list): List of lists, where
+                repo_groups[i] contains the repo slugs from queries[i].
         """
 
         queries = []
+        repo_groups = []
 
-        for i in range(0, len(repos), 50):
-            chunk = repos[i : i + 50]
+        for i in range(0, len(repos), batch_size):
+            chunk = repos[i : i + batch_size]
             repo_queries = []
 
             for j, repo in enumerate(chunk):
@@ -204,32 +208,42 @@ class GqlQueries:
                     + "\n}"
                 }
             )
+            repo_groups.append(list(chunk))
 
-        return queries
+        return queries, repo_groups
 
     @staticmethod
-    def get_workflow_ymls(repos: list):
+    def get_workflow_ymls(repos: list, batch_size: int = 50):
         """Retrieve workflow yml files for each repository.
 
         Args:
             repos (List[Repository]): List of repository objects
+            batch_size (int, optional): Maximum number of repos per
+            GraphQL query. Defaults to 50.
+
         Returns:
-            (list): List of JSON post parameters for each graphQL query.
+            tuple: (queries, repo_groups) where:
+                queries (list): List of JSON post parameters for
+                each GraphQL query.
+                repo_groups (list): List of lists, where
+                repo_groups[i] contains the Repository objects
+                from queries[i].
         """
         queries = []
+        repo_groups = []
 
         if len(repos) == 0:
-            return queries
+            return queries, repo_groups
 
-        for i in range(0, (len(repos) // 100) + 1):
-            top_len = len(repos) if len(repos) < 100 * (i + 1) else 100 * (i + 1)
+        for i in range(0, len(repos), batch_size):
+            chunk = repos[i : i + batch_size]
             # Use reduce to accumulate node_ids and can_push in a single iteration
             node_ids, can_push = reduce(
                 lambda acc, repo: (
                     acc[0] + [repo.repo_data["node_id"]],
                     acc[1] or repo.can_push(),
                 ),
-                repos[100 * i : top_len],
+                chunk,
                 ([], False),
             )
 
@@ -241,4 +255,6 @@ class GqlQueries:
             }
 
             queries.append(query)
-        return queries
+            repo_groups.append(list(chunk))
+
+        return queries, repo_groups


### PR DESCRIPTION
## Summary

Reduces GraphQL repository batch sizes from 50/100 to 30 to avoid 502 Bad Gateway errors on large organizations.

### Problem
Large orgs (e.g. Azure with 1929 repos) trigger 502 errors because the current chunk sizes of 50 (for workflow YAML queries) and 100 (for default branch/submodule queries) produce queries that are too large.

### Fix
- Reduced  chunk size: 50 → 30
- Reduced  chunk size: 100 → 30

### Note
The  flag was already merged as part of PR #269, so this PR only addresses the batch size reduction.

## Test plan
- [x] All 585 existing tests pass