### PR TITLE
fix(search): preserve reserved custom query characters

### DIFF
--- a/gatox/github/search.py
+++ b/gatox/github/search.py
@@ -45,15 +45,15 @@ class Search:
                 f"self-hosted org:{organization} language:yaml path:.github/workflows"
             )
 
-        next_page = (
-            f"/search/code?q={query['q']}&sort={query['sort']}"
-            f"&per_page={query['per_page']}&page={query['page']}"
-        )
+        next_page = "/search/code"
+        next_page_params = query
 
         Output.info("Searching", end="", flush=True)
         candidates = set()
         while next_page:
-            result = await self.api_accessor.call_get(next_page)
+            result = await self.api_accessor.call_get(
+                next_page, params=next_page_params
+            )
             print(".", end="", flush=True)
             code = result.status_code
             data = result.json()
@@ -97,6 +97,7 @@ class Search:
                 candidates.add(entry["repository"]["full_name"])
 
             next_page = result.links.get("next", {}).get("url")
+            next_page_params = None
             if next_page:
                 link = urlparse(next_page)
                 next_page = f"{link.path}?{link.query}"

--- a/unit_test/test_search.py
+++ b/unit_test/test_search.py
@@ -1,11 +1,16 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import httpx
 
 from gatox.cli.output import Output
+from gatox.github.api_base import ApiBase
 from gatox.github.search import Search
 from gatox.search.search import Searcher
 from unit_test.api_mock import make_api_mock
 
 Output(True)
+
+_HTTPX_ASYNC_CLIENT_SEND = httpx.AsyncClient.send
 
 
 @patch("gatox.github.search.asyncio.sleep")
@@ -72,6 +77,69 @@ async def test_search_api_encodes_custom_query_as_params(mock_time):
             "page": 1,
         },
     )
+
+
+async def test_search_api_preserves_reserved_query_characters(monkeypatch):
+    requests = []
+    custom_query = (
+        "org:somecompany lang:yaml path:.github/workflows "
+        r"/pull_request_target.+write/"
+    )
+
+    def handle_request(request):
+        requests.append(request)
+        return httpx.Response(
+            status_code=200,
+            json={"items": [], "total_count": 0},
+        )
+
+    # The autouse fixture blocks AsyncClient.send; restore it for MockTransport.
+    monkeypatch.setattr(httpx.AsyncClient, "send", _HTTPX_ASYNC_CLIENT_SEND)
+    transport = httpx.MockTransport(handle_request)
+    async with httpx.AsyncClient(transport=transport) as client:
+        searcher = Search(ApiBase("test-token", client=client))
+        await searcher.search_enumeration(custom_query=custom_query)
+
+    assert len(requests) == 1
+    assert requests[0].url.path == "/search/code"
+    assert requests[0].url.params["q"] == custom_query
+    assert b"%2B" in requests[0].url.query
+
+
+@patch("gatox.github.search.asyncio.sleep")
+async def test_search_api_uses_next_link_without_initial_params(mock_time):
+    mock_client = AsyncMock()
+    custom_query = "org:somecompany path:.github/workflows"
+    next_page = "https://api.github.com/search/code?q=custom&page=2"
+    mock_client.call_get.side_effect = [
+        MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"items": [], "total_count": 0}),
+            links={"next": {"url": next_page}},
+        ),
+        MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"items": [], "total_count": 0}),
+            links={},
+        ),
+    ]
+
+    searcher = Search(mock_client)
+    await searcher.search_enumeration(custom_query=custom_query)
+
+    assert mock_client.call_get.await_args_list == [
+        call(
+            "/search/code",
+            params={
+                "q": custom_query,
+                "sort": "indexed",
+                "per_page": "100",
+                "page": 1,
+            },
+        ),
+        call("/search/code?q=custom&page=2", params=None),
+    ]
+    mock_time.assert_awaited_once_with(5)
 
 
 @patch("gatox.github.search.asyncio.sleep")

--- a/unit_test/test_search.py
+++ b/unit_test/test_search.py
@@ -46,6 +46,35 @@ async def test_search_api(mock_time):
 
 
 @patch("gatox.github.search.asyncio.sleep")
+async def test_search_api_encodes_custom_query_as_params(mock_time):
+    mock_client = AsyncMock()
+    custom_query = (
+        "org:somecompany lang:yaml path:.github/workflows "
+        "/(issue_comment|pull_request_target|issues:)/"
+    )
+
+    mock_client.call_get.return_value = MagicMock(
+        status_code=200,
+        json=MagicMock(return_value={"items": [], "total_count": 0}),
+        links={},
+    )
+
+    searcher = Search(mock_client)
+
+    await searcher.search_enumeration(custom_query=custom_query)
+
+    mock_client.call_get.assert_awaited_once_with(
+        "/search/code",
+        params={
+            "q": custom_query,
+            "sort": "indexed",
+            "per_page": "100",
+            "page": 1,
+        },
+    )
+
+
+@patch("gatox.github.search.asyncio.sleep")
 async def test_search_api_cap(mock_time, capfd):
     mock_client = AsyncMock()
 


### PR DESCRIPTION
## Summary

- pass initial GitHub code-search parameters through HTTPX query parameters so
  regex quantifiers and other reserved characters retain their original meaning
- follow GitHub-provided pagination links without replaying the initial query
  parameters
- add transport-level and two-page pagination regressions

## Why

Interpolating a custom query directly into the URL can change its meaning before
it reaches GitHub. For example, HTTPX interprets the `+` in
`/pull_request_target.+write/` as a space when it is embedded in the raw URL.

Passing the query through `params=` encodes the plus as `%2B` and preserves the
original regex. Pagination must then follow GitHub's complete `Link` URL without
adding the initial parameters a second time.

Related to #276. The exact reported search cannot be verified because its
organization is private, so this change is scoped to the independently
reproduced reserved-character failure.

## Testing

- focused search regressions: 4/4 passed
- full unit suite: 590/590 passed, 76.42% coverage
- `venv/bin/ruff check gatox/github/search.py unit_test/test_search.py`
- `venv/bin/ruff format --check gatox/github/search.py unit_test/test_search.py`
- `venv/bin/black --check gatox/github/search.py unit_test/test_search.py`
- `venv/bin/isort --check-only gatox/github/search.py unit_test/test_search.py`
- `venv/bin/pyright` — zero errors
- `git diff --check`

Repository-wide Ruff/format is not claimed: current `main` has an existing
import-order finding in `unit_test/test_runlog_parser.py` plus existing docs
formatting findings, none in this PR's files.

## AI assistance

OpenAI Codex assisted with investigation, regression-test design, implementation,
and validation. I reviewed the final diff and take responsibility for it.
