### PR TITLE
Fix nondeterministic pwn-request detection for workflows with multiple triggers

### DIFF
--- a/gatox/workflow_graph/nodes/workflow.py
+++ b/gatox/workflow_graph/nodes/workflow.py
@@ -202,9 +202,8 @@ class WorkflowNode(Node):
         """
         if trigger is not None:
             return trigger in self.__excluded_triggers
-        # If no trigger specified, check if all triggers are excluded
-        return len(self.__excluded_triggers) > 0 and len(self.__triggers) == len(
-            self.__excluded_triggers
+        return bool(self.__excluded_triggers) and all(
+            trigger in self.__excluded_triggers for trigger in self.__triggers
         )
 
     def get_env_vars(self):

--- a/gatox/workflow_graph/visitors/pwn_request_visitor.py
+++ b/gatox/workflow_graph/visitors/pwn_request_visitor.py
@@ -182,24 +182,7 @@ class PwnRequestVisitor:
                     if repo and repo.is_fork():
                         break
 
-                    # Determine the trigger for this path
-                    path_trigger = None
-                    for tag in tags:
-                        if tag in [
-                            "pull_request_target",
-                            "pull_request_target:labeled",
-                            "issue_comment",
-                            "workflow_run",
-                            "workflow_dispatch",
-                        ]:
-                            path_trigger = tag
-                            break
-
-                    # Check if this specific trigger is excluded
-                    if path_trigger and node.excluded(path_trigger):
-                        break
-                    # If we couldn't determine the trigger, fall back to checking all triggers
-                    elif not path_trigger and node.excluded():
+                    if node.excluded():
                         break
 
                     if "pull_request_target:labeled" in tags:

--- a/unit_test/graph/test_workflow_node.py
+++ b/unit_test/graph/test_workflow_node.py
@@ -1,0 +1,40 @@
+import pytest
+import yaml
+
+from gatox.models.workflow import Workflow
+from gatox.workflow_graph.nodes.workflow import WorkflowNode
+
+
+def make_node(on: dict) -> WorkflowNode:
+    yml = {"on": on, "jobs": {"build": {"runs-on": "ubuntu-latest", "steps": []}}}
+    workflow = Workflow("test/repo", yaml.dump(yml), "test.yml")
+    node = WorkflowNode("main", "test/repo", ".github/workflows/test.yml")
+    node.initialize(workflow)
+    return node
+
+
+@pytest.mark.parametrize(
+    "on, expected",
+    [
+        ({"workflow_dispatch": {"inputs": {"name": {"type": "string"}}}}, True),
+        ({"workflow_dispatch": None}, True),
+        ({"workflow_run": {"workflows": ["CI"], "branches": ["main"]}}, True),
+        (
+            {
+                "workflow_dispatch": {"inputs": {"name": {"type": "string"}}},
+                "workflow_run": {"workflows": ["CI"], "types": ["completed"]},
+            },
+            False,
+        ),
+        (
+            {
+                "pull_request_target": None,
+                "workflow_run": {"workflows": ["CI"], "branches": ["main"]},
+            },
+            False,
+        ),
+        ({"pull_request_target": None}, False),
+    ],
+)
+def test_excluded_only_when_no_trigger_is_open(on, expected):
+    assert make_node(on).excluded() is expected


### PR DESCRIPTION
Hi!

This is a subtle bug we found out where the same workflow could produce a pwn-request finding in one Python process and no finding in another. The result depended on set iteration order, which can vary with PYTHONHASHSEED.

Workflow triggers are put into a set, and in the PwnRequestVisitor, when checking if the node can be triggered externally, the old code only looked at a single trigger:

```python
path_trigger = None
for tag in tags: # node.get_tags() returns a set with unspecified iteration order
    if tag in [
        "pull_request_target",
        "pull_request_target:labeled",
        "issue_comment",
        "workflow_run",
        "workflow_dispatch",
    ]:
        path_trigger = tag
        break
``` 

For a workflow with an open `workflow_run` and an excluded `workflow_dispatch`, if the first tag is `workflow_run` then it goes through because `excluded("workflow_run")` returns `False`, but if in another run the first tag is `workflow_dispatch` then it will be excluded because `excluded("workflow_dispatch")` returns `True`.

The visitor now calls `node.excluded()` to check whether all workflow triggers are excluded, instead of selecting the first matching tag. `WorkflowNode.excluded()` also previously compared collection sizes, which could incorrectly exclude an open `pull_request_target` alongside a branch-filtered `workflow_run`. It now checks whether each trigger is excluded.

### Replication

We have a live reproduction case we can share privately.